### PR TITLE
Bug 1825029: Add monitoring label to ingress namespace

### DIFF
--- a/assets/cluster-bootstrap/00000_namespaces-needed-for-monitoring.yaml
+++ b/assets/cluster-bootstrap/00000_namespaces-needed-for-monitoring.yaml
@@ -32,4 +32,6 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
   name: openshift-ingress

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -141,6 +141,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
   name: openshift-ingress
 `)
 


### PR DESCRIPTION
Adds label needed to include the default router in prometheus metrics.