### PR TITLE
Use explicit variable for OAuth DNS endpoint

### DIFF
--- a/assets/kube-apiserver/oauthMetadata.json
+++ b/assets/kube-apiserver/oauthMetadata.json
@@ -1,8 +1,8 @@
 {
 {{ if ne .ExternalOauthPort 0 }}
-"issuer": "https://{{ .ExternalAPIDNSName }}:{{ .ExternalOauthPort }}",
-"authorization_endpoint": "https://{{ .ExternalAPIDNSName }}:{{ .ExternalOauthPort }}/oauth/authorize",
-"token_endpoint": "https://{{ .ExternalAPIDNSName }}:{{ .ExternalOauthPort }}/oauth/token",
+"issuer": "https://{{ .ExternalOauthDNSName }}:{{ .ExternalOauthPort }}",
+"authorization_endpoint": "https://{{ .ExternalOauthDNSName }}:{{ .ExternalOauthPort }}/oauth/authorize",
+"token_endpoint": "https://{{ .ExternalOauthDNSName }}:{{ .ExternalOauthPort }}/oauth/token",
 {{ else }}
 "issuer": "https://oauth-openshift.{{ .IngressSubdomain }}",
 "authorization_endpoint": "https://oauth-openshift.{{ .IngressSubdomain }}/oauth/authorize",

--- a/assets/oauth-openshift/oauth-browser-client.yaml
+++ b/assets/oauth-openshift/oauth-browser-client.yaml
@@ -10,5 +10,5 @@ data:
     metadata:
       name: openshift-browser-client
     redirectURIs:
-    - https://{{ .ExternalAPIDNSName }}:{{ .ExternalOauthPort }}/oauth/token/display
+    - https://{{ .ExternalOauthDNSName }}:{{ .ExternalOauthPort }}/oauth/token/display
     secret: "{{ randomString 32  }}"

--- a/assets/oauth-openshift/oauth-challenging-client.yaml
+++ b/assets/oauth-openshift/oauth-challenging-client.yaml
@@ -10,5 +10,5 @@ data:
     metadata:
       name: openshift-challenging-client
     redirectURIs:
-    - https://{{ .ExternalAPIDNSName }}:{{ .ExternalOauthPort }}/oauth/token/implicit
+    - https://{{ .ExternalOauthDNSName }}:{{ .ExternalOauthPort }}/oauth/token/implicit
     respondWithChallenges: true

--- a/assets/oauth-openshift/oauth-server-config.yaml
+++ b/assets/oauth-openshift/oauth-server-config.yaml
@@ -31,8 +31,8 @@ oauthConfig:
 {{ if .NamedCerts }}  masterCA: ""
 {{- else }}  masterCA: "/etc/oauth-openshift-config/ca.crt"
 {{- end }}
-  masterPublicURL: https://{{ .ExternalAPIDNSName }}:{{ .ExternalOauthPort }}
-  masterURL: https://{{ .ExternalAPIDNSName }}:{{ .ExternalOauthPort }}
+  masterPublicURL: https://{{ .ExternalOauthDNSName }}:{{ .ExternalOauthPort }}
+  masterURL: https://{{ .ExternalOauthDNSName }}:{{ .ExternalOauthPort }}
   sessionConfig:
     sessionMaxAgeSeconds: 300
     sessionName: ssn

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -5,6 +5,7 @@ type ClusterParams struct {
 	ExternalAPIDNSName                  string                 `json:"externalAPIDNSName"`
 	ExternalAPIPort                     uint                   `json:"externalAPIPort"`
 	ExternalAPIIPAddress                string                 `json:"externalAPIAddress"`
+	ExternalOauthDNSName                string                 `json:"externalOauthDNSName"`
 	ExternalOauthPort                   uint                   `json:"externalOauthPort"`
 	IdentityProviders                   string                 `json:"identityProviders"`
 	ServiceCIDR                         string                 `json:"serviceCIDR"`

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1235,9 +1235,9 @@ func kubeApiserverKubeApiserverServiceYaml() (*asset, error) {
 
 var _kubeApiserverOauthmetadataJson = []byte(`{
 {{ if ne .ExternalOauthPort 0 }}
-"issuer": "https://{{ .ExternalAPIDNSName }}:{{ .ExternalOauthPort }}",
-"authorization_endpoint": "https://{{ .ExternalAPIDNSName }}:{{ .ExternalOauthPort }}/oauth/authorize",
-"token_endpoint": "https://{{ .ExternalAPIDNSName }}:{{ .ExternalOauthPort }}/oauth/token",
+"issuer": "https://{{ .ExternalOauthDNSName }}:{{ .ExternalOauthPort }}",
+"authorization_endpoint": "https://{{ .ExternalOauthDNSName }}:{{ .ExternalOauthPort }}/oauth/authorize",
+"token_endpoint": "https://{{ .ExternalOauthDNSName }}:{{ .ExternalOauthPort }}/oauth/token",
 {{ else }}
 "issuer": "https://oauth-openshift.{{ .IngressSubdomain }}",
 "authorization_endpoint": "https://oauth-openshift.{{ .IngressSubdomain }}/oauth/authorize",
@@ -1729,7 +1729,7 @@ data:
     metadata:
       name: openshift-browser-client
     redirectURIs:
-    - https://{{ .ExternalAPIDNSName }}:{{ .ExternalOauthPort }}/oauth/token/display
+    - https://{{ .ExternalOauthDNSName }}:{{ .ExternalOauthPort }}/oauth/token/display
     secret: "{{ randomString 32  }}"
 `)
 
@@ -1760,7 +1760,7 @@ data:
     metadata:
       name: openshift-challenging-client
     redirectURIs:
-    - https://{{ .ExternalAPIDNSName }}:{{ .ExternalOauthPort }}/oauth/token/implicit
+    - https://{{ .ExternalOauthDNSName }}:{{ .ExternalOauthPort }}/oauth/token/implicit
     respondWithChallenges: true
 `)
 
@@ -1836,8 +1836,8 @@ oauthConfig:
 {{ if .NamedCerts }}  masterCA: ""
 {{- else }}  masterCA: "/etc/oauth-openshift-config/ca.crt"
 {{- end }}
-  masterPublicURL: https://{{ .ExternalAPIDNSName }}:{{ .ExternalOauthPort }}
-  masterURL: https://{{ .ExternalAPIDNSName }}:{{ .ExternalOauthPort }}
+  masterPublicURL: https://{{ .ExternalOauthDNSName }}:{{ .ExternalOauthPort }}
+  masterURL: https://{{ .ExternalOauthDNSName }}:{{ .ExternalOauthPort }}
   sessionConfig:
     sessionMaxAgeSeconds: 300
     sessionName: ssn

--- a/pkg/cmd/render/manifests.go
+++ b/pkg/cmd/render/manifests.go
@@ -42,6 +42,9 @@ func (o *RenderManifestsOptions) Run() error {
 		log.WithError(err).Fatalf("Error occurred reading configuration")
 	}
 	externalOauth := params.ExternalOauthPort != 0
+	if len(params.ExternalOauthDNSName) == 0 {
+		params.ExternalOauthDNSName = params.ExternalAPIDNSName
+	}
 	err = render.RenderClusterManifests(params, o.PullSecretFile, o.OutputDir, externalOauth, o.IncludeRegistry)
 	if err != nil {
 		return err


### PR DESCRIPTION
Introduces field for ExternalOauthDNSName but defaults it to ExternalAPIDNSName if not set. This is just to facilitate testing and should have no functional impact.