### PR TITLE
Mount pull secret in openshift api-server pod

### DIFF
--- a/assets/openshift-apiserver/openshift-apiserver-deployment.yaml
+++ b/assets/openshift-apiserver/openshift-apiserver-deployment.yaml
@@ -88,6 +88,8 @@ spec:
           name: config
         - mountPath: /var/run/kubernetes
           name: logs
+        - mountPath: /var/lib/kubelet
+          name: pull-secret
         workingDir: /var/run/kubernetes
       volumes:
       - secret:
@@ -101,3 +103,10 @@ spec:
         name: apiserver-config
       - emptyDir: {}
         name: logs
+      - name: pull-secret
+        secret:
+          secretName: pull-secret
+          items:
+          - key: .dockerconfigjson
+            path: config.json
+            mode: 220

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2624,6 +2624,8 @@ spec:
           name: config
         - mountPath: /var/run/kubernetes
           name: logs
+        - mountPath: /var/lib/kubelet
+          name: pull-secret
         workingDir: /var/run/kubernetes
       volumes:
       - secret:
@@ -2637,6 +2639,13 @@ spec:
         name: apiserver-config
       - emptyDir: {}
         name: logs
+      - name: pull-secret
+        secret:
+          secretName: pull-secret
+          items:
+          - key: .dockerconfigjson
+            path: config.json
+            mode: 220
 `)
 
 func openshiftApiserverOpenshiftApiserverDeploymentYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Starting in 4.5 the openshift samples operator no longer explicitly copies the pull secret from `openshift-config` to the `openshift` namespace. Now it relies on the openshift apiserver to mount the pull secret from the file system of the node. In a ROKS deployment, the pull secret is available in the same namespace as the openshift apiserver pod. It's just a matter of mounting it where expected so the apiserver can use it to import samples as well.

See https://github.com/openshift/openshift-apiserver/pull/83
and https://github.com/openshift/enhancements/pull/136