### PR TITLE
Reduce reliance on cache in the controller manager CA controller

### DIFF
--- a/pkg/cmd/cpoperator/operator-config.go
+++ b/pkg/cmd/cpoperator/operator-config.go
@@ -3,6 +3,7 @@ package cpoperator
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/go-logr/logr"
 
@@ -143,9 +144,13 @@ func (c *ControlPlaneOperatorConfig) TargetConfigInformers() configinformers.Sha
 }
 
 func (c *ControlPlaneOperatorConfig) TargetKubeInformersForNamespace(namespace string) informers.SharedInformerFactory {
+	return c.TargetKubeInformersForNamespaceWithInterval(namespace, common.DefaultResync)
+}
+
+func (c *ControlPlaneOperatorConfig) TargetKubeInformersForNamespaceWithInterval(namespace string, syncInterval time.Duration) informers.SharedInformerFactory {
 	informer, exists := c.namespacedInformers[namespace]
 	if !exists {
-		informer = informers.NewSharedInformerFactoryWithOptions(c.TargetKubeClient(), common.DefaultResync, informers.WithNamespace(namespace))
+		informer = informers.NewSharedInformerFactoryWithOptions(c.TargetKubeClient(), syncInterval, informers.WithNamespace(namespace))
 		if c.namespacedInformers == nil {
 			c.namespacedInformers = map[string]informers.SharedInformerFactory{}
 		}

--- a/pkg/controllers/openshift_apiserver/controller.go
+++ b/pkg/controllers/openshift_apiserver/controller.go
@@ -244,7 +244,6 @@ func filterManagedConfigKeys(in []byte) (out []byte, err error) {
 
 // UpdateOperatorStatus updates the status of the operator, assuming the given resource version.
 func (c *apiServerOperatorClient) UpdateOperatorStatus(oldResourceVersion string, in *operatorv1.OperatorStatus) (out *operatorv1.OperatorStatus, err error) {
-	c.Logger.Info("Update called on operator status", "status", in)
 	return
 }
 

--- a/pkg/controllers/openshift_controller_manager/operator_client.go
+++ b/pkg/controllers/openshift_controller_manager/operator_client.go
@@ -153,7 +153,6 @@ func filterManagedConfigKeys(in []byte) (out []byte, err error) {
 
 // UpdateOperatorStatus updates the status of the operator, assuming the given resource version.
 func (c *cmOperatorClient) UpdateOperatorStatus(oldResourceVersion string, in *operatorv1.OperatorStatus) (out *operatorv1.OperatorStatus, err error) {
-	c.Logger.Info("Update called on operator status", "status", in)
 	return
 }
 


### PR DESCRIPTION
The CA values that the CMCA controller uses to update the kube controller manager CA could potentially get out of sync in one of 2 ways:
- The event that resulted in the appearance of the CA configmap was somehow missed. In that case, it would take 10 hours to do a relist of the configmaps to update the CA.
- The configmap cached in memory somehow got out of date, but it's what was used to update the controller manager CA.

To mitigate these, the code has been changed to get the configmaps directly via client calls instead of using the lister, and reduced the relist interval for the informer to 10min, so in case an event was missed, it would be caught again in a relatively short amount of time.