### PR TITLE
Fix permissions for security allocation controller

### DIFF
--- a/assets/cluster-bootstrap/namespace-security-allocation-controller-clusterrole.yaml
+++ b/assets/cluster-bootstrap/namespace-security-allocation-controller-clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
 rules:
 - apiGroups:
   - security.openshift.io
+  - security.internal.openshift.io
   resources:
   - rangeallocations
   verbs:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -495,6 +495,7 @@ metadata:
 rules:
 - apiGroups:
   - security.openshift.io
+  - security.internal.openshift.io
   resources:
   - rangeallocations
   verbs:


### PR DESCRIPTION
Adds additional API group for rangeallocations resource in the cluster role for the security allocation controller. Only needed for 4.6+