### PR TITLE
Enable service account issuer so that TokenRequests work

### DIFF
--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -42,6 +42,12 @@ apiServerArguments:
   - "{{ .ExternalAPIIPAddress }}"
   cloud-provider:
   - "{{ .CloudProvider }}"
+  service-account-issuer:
+  - https://kubernetes.default.svc
+  service-account-signing-key-file:
+  - /etc/kubernetes/secret/service-account.key
+  api-audiences:
+  - https://kubernetes.default.svc
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true

--- a/assets/kube-apiserver/kube-apiserver-secret.yaml
+++ b/assets/kube-apiserver/kube-apiserver-secret.yaml
@@ -11,3 +11,4 @@ data:
   etcd-client.key: {{ pki "etcd-client.key" }}
   proxy-client.crt: {{ pki "kube-apiserver-aggregator-proxy-client.crt" }}
   proxy-client.key: {{ pki "kube-apiserver-aggregator-proxy-client.key" }}
+  service-account.key: {{ pki "service-account.key" }}

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -938,6 +938,12 @@ apiServerArguments:
   - "{{ .ExternalAPIIPAddress }}"
   cloud-provider:
   - "{{ .CloudProvider }}"
+  service-account-issuer:
+  - https://kubernetes.default.svc
+  service-account-signing-key-file:
+  - /etc/kubernetes/secret/service-account.key
+  api-audiences:
+  - https://kubernetes.default.svc
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true
@@ -1374,6 +1380,7 @@ data:
   etcd-client.key: {{ pki "etcd-client.key" }}
   proxy-client.crt: {{ pki "kube-apiserver-aggregator-proxy-client.crt" }}
   proxy-client.key: {{ pki "kube-apiserver-aggregator-proxy-client.key" }}
+  service-account.key: {{ pki "service-account.key" }}
 `)
 
 func kubeApiserverKubeApiserverSecretYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Requires a new entry in the kube apiserver secret with the service account signer (same as in kube controller manager).