### PR TITLE
Use Prometheus PushGateway to push CVO metrics to user cluster

### DIFF
--- a/Dockerfile.metrics
+++ b/Dockerfile.metrics
@@ -1,10 +1,16 @@
 FROM openshift/origin-release:golang-1.14 as builder
 RUN mkdir -p /go/src/github.com/openshift/ibm-roks-toolkit
+ENV PUSHGATEWAY_VERSION="1.3.0"
 WORKDIR /go/src/github.com/openshift/ibm-roks-toolkit
 COPY . .
 RUN go build -mod=vendor -o ./bin/roks-metrics ./cmd/roks-metrics/main.go
-
+RUN cd /tmp && \
+    curl -OL https://github.com/prometheus/pushgateway/releases/download/v${PUSHGATEWAY_VERSION}/pushgateway-${PUSHGATEWAY_VERSION}.linux-amd64.tar.gz && \
+    tar -xzf pushgateway-${PUSHGATEWAY_VERSION}.linux-amd64.tar.gz && \
+    cp pushgateway-${PUSHGATEWAY_VERSION}.linux-amd64/pushgateway /pushgateway
+  
 FROM registry.access.redhat.com/ubi7/ubi
 RUN yum -y update && yum clean all
 COPY --from=builder /go/src/github.com/openshift/ibm-roks-toolkit/bin/roks-metrics /usr/bin/roks-metrics
+COPY --from=builder /pushgateway /usr/bin/pushgateway
 ENTRYPOINT /usr/bin/roks-metrics

--- a/Dockerfile.metrics
+++ b/Dockerfile.metrics
@@ -4,6 +4,7 @@ ENV PUSHGATEWAY_VERSION="1.3.0"
 WORKDIR /go/src/github.com/openshift/ibm-roks-toolkit
 COPY . .
 RUN go build -mod=vendor -o ./bin/roks-metrics ./cmd/roks-metrics/main.go
+RUN go build -mod=vendor -o ./bin/metrics-pusher ./cmd/metrics-pusher/main.go
 RUN cd /tmp && \
     curl -OL https://github.com/prometheus/pushgateway/releases/download/v${PUSHGATEWAY_VERSION}/pushgateway-${PUSHGATEWAY_VERSION}.linux-amd64.tar.gz && \
     tar -xzf pushgateway-${PUSHGATEWAY_VERSION}.linux-amd64.tar.gz && \
@@ -12,5 +13,6 @@ RUN cd /tmp && \
 FROM registry.access.redhat.com/ubi7/ubi
 RUN yum -y update && yum clean all
 COPY --from=builder /go/src/github.com/openshift/ibm-roks-toolkit/bin/roks-metrics /usr/bin/roks-metrics
+COPY --from=builder /go/src/github.com/openshift/ibm-roks-toolkit/bin/metrics-pusher /usr/bin/metrics-pusher
 COPY --from=builder /pushgateway /usr/bin/pushgateway
 ENTRYPOINT /usr/bin/roks-metrics

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ control-plane-operator:
 .PHONY: roks-metrics
 roks-metrics:
 	go build -mod=vendor -o ./bin/roks-metrics ./cmd/roks-metrics/main.go
+	go build -mod=vendor -o ./bin/metrics-pusher ./cmd/metrics-pusher/main.go
 
 test:
 	./hack/test.sh

--- a/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
+++ b/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
@@ -75,6 +75,24 @@ spec:
                   fieldPath: spec.nodeName
             - name: EXCLUDE_MANIFESTS
               value: internal-openshift-hosted
+{{ if .ROKSMetricsImage }}
+        - name: metrics-pusher
+          image: {{ .ROKSMetricsImage }}
+          imagePullPolicy: Always
+          command:
+            - "metrics-pusher"
+          args:
+            - "--destination-path=/api/v1/namespaces/openshift-roks-metrics/services/push-gateway:http/proxy/metrics"
+            - "--kubeconfig=/etc/openshift/kubeconfig/kubeconfig"
+            - "--job=cluster-version-operator"
+            - "--frequency=30s"
+            - "--source-url=http://localhost:9099/metrics"
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/openshift/kubeconfig
+              name: kubeconfig
+              readOnly: true
+{{ end }}
       volumes:
         - name: work
           emptyDir: {}

--- a/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
+++ b/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
@@ -82,9 +82,8 @@ spec:
           command:
             - "metrics-pusher"
           args:
-            - "--destination-path=/api/v1/namespaces/openshift-roks-metrics/services/push-gateway:http/proxy/metrics"
+            - "--destination-path=/api/v1/namespaces/openshift-roks-metrics/services/push-gateway:http/proxy/metrics/job/cluster-version-operator"
             - "--kubeconfig=/etc/openshift/kubeconfig/kubeconfig"
-            - "--job=cluster-version-operator"
             - "--frequency=30s"
             - "--source-url=http://localhost:9099/metrics"
           terminationMessagePolicy: FallbackToLogsOnError

--- a/assets/roks-metrics/roks-metrics-deployment.yaml
+++ b/assets/roks-metrics/roks-metrics-deployment.yaml
@@ -41,6 +41,14 @@ spec:
         volumeMounts:
         - name: serving-cert
           mountPath: /var/run/secrets/serving-cert
+      - name: push-gateway
+        image: {{ .ROKSMetricsImage }}
+        imagePullPolicy: Always
+        command:
+        - pushgateway
+        ports:
+        - containerPort: 9091
+          name: gateway
       serviceAccountName: roks-metrics 
       volumes:
       - name: serving-cert

--- a/assets/roks-metrics/roks-metrics-push-gateway-deployment.yaml
+++ b/assets/roks-metrics/roks-metrics-push-gateway-deployment.yaml
@@ -1,7 +1,7 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: metrics
+  name: push-gateway
   namespace: openshift-roks-metrics
 spec:
   replicas: 1
@@ -12,11 +12,11 @@ spec:
       maxUnavailable: 1
   selector:
     matchLabels:
-      app: metrics
+      app: push-gateway
   template:
     metadata:
       labels:
-        app: metrics
+        app: push-gateway
 {{ if .RestartDate }}
       annotations:
         openshift.io/restartedAt: "{{ .RestartDate }}"
@@ -28,23 +28,11 @@ spec:
           value: "true"
           effect: NoSchedule
       containers:
-      - name: metrics
+      - name: push-gateway
         image: {{ .ROKSMetricsImage }}
         imagePullPolicy: Always
-        args:
-        - "--alsologtostderr"
-        - "--v=3"
-        - "--listen=:8443"
+        command:
+        - pushgateway
         ports:
-        - containerPort: 8443
-          name: https
-        volumeMounts:
-        - name: serving-cert
-          mountPath: /var/run/secrets/serving-cert
-      serviceAccountName: roks-metrics 
-      volumes:
-      - name: serving-cert
-        secret:
-          secretName: serving-cert
-          defaultMode: 400
-          optional: true
+        - containerPort: 9091
+          name: http

--- a/assets/roks-metrics/roks-metrics-push-gateway-service.yaml
+++ b/assets/roks-metrics/roks-metrics-push-gateway-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: push-gateway
+  namespace: openshift-roks-metrics
+  labels:
+    app: metrics-push-gateway
+spec:
+  ports:
+  - name: http
+    port: 9091
+    protocol: TCP
+    targetPort: gateway
+  selector:
+    app: metrics
+  type: ClusterIP

--- a/assets/roks-metrics/roks-metrics-push-gateway-service.yaml
+++ b/assets/roks-metrics/roks-metrics-push-gateway-service.yaml
@@ -4,13 +4,13 @@ metadata:
   name: push-gateway
   namespace: openshift-roks-metrics
   labels:
-    app: metrics-push-gateway
+    app: push-gateway
 spec:
   ports:
   - name: http
     port: 9091
     protocol: TCP
-    targetPort: gateway
+    targetPort: http
   selector:
-    app: metrics
+    app: push-gateway
   type: ClusterIP

--- a/assets/roks-metrics/roks-metrics-push-gateway-servicemonitor.yaml
+++ b/assets/roks-metrics/roks-metrics-push-gateway-servicemonitor.yaml
@@ -8,8 +8,7 @@ spec:
   - interval: 30s
     path: /metrics
     port: http
-    scheme: http
-  jobLabel: component
+    honorLabels: true
   selector:
     matchLabels:
       app: metrics-push-gateway

--- a/assets/roks-metrics/roks-metrics-push-gateway-servicemonitor.yaml
+++ b/assets/roks-metrics/roks-metrics-push-gateway-servicemonitor.yaml
@@ -11,4 +11,4 @@ spec:
     honorLabels: true
   selector:
     matchLabels:
-      app: metrics-push-gateway
+      app: push-gateway

--- a/assets/roks-metrics/roks-metrics-push-gateway-servicemonitor.yaml
+++ b/assets/roks-metrics/roks-metrics-push-gateway-servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: roks-metrics-push-gateway
+  namespace: openshift-roks-metrics
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: http
+    scheme: http
+  jobLabel: component
+  selector:
+    matchLabels:
+      app: metrics-push-gateway

--- a/cmd/metrics-pusher/main.go
+++ b/cmd/metrics-pusher/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/openshift/ibm-roks-toolkit/pkg/metrics_pusher"
+)
+
+func main() {
+	if err := newMetricsPusherCommand().Execute(); err != nil {
+		fmt.Fprintf(os.Stdout, "Error: %v", err)
+	}
+}
+
+func newMetricsPusherCommand() *cobra.Command {
+
+	metricsPusher := metrics_pusher.MetricsPusher{}
+	cmd := &cobra.Command{
+		Use:          "metrics-pusher",
+		Short:        "Pushes metrics to a given endpoint inside a cluster",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log.SetLogger(zap.New())
+			metricsPusher.Log = ctrl.Log.WithName("metrics-pusher")
+			return metricsPusher.Run()
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVar(&metricsPusher.SourceURL, "source-url", "", "Source URL to poll for metrics")
+	flags.StringVar(&metricsPusher.DestinationPath, "destination-path", "", "URL path to use as a destination on the target cluster")
+	flags.StringVar(&metricsPusher.Kubeconfig, "kubeconfig", "", "Kubeconfig file for destination cluster")
+	flags.StringVar(&metricsPusher.Job, "job", "", "Job to use when pushing metrics to cluster")
+	flags.DurationVar(&metricsPusher.Frequency, "frequency", 30*time.Second, "Frequency with which to push metrics")
+	return cmd
+}

--- a/cmd/metrics-pusher/main.go
+++ b/cmd/metrics-pusher/main.go
@@ -37,7 +37,6 @@ func newMetricsPusherCommand() *cobra.Command {
 	flags.StringVar(&metricsPusher.SourceURL, "source-url", "", "Source URL to poll for metrics")
 	flags.StringVar(&metricsPusher.DestinationPath, "destination-path", "", "URL path to use as a destination on the target cluster")
 	flags.StringVar(&metricsPusher.Kubeconfig, "kubeconfig", "", "Kubeconfig file for destination cluster")
-	flags.StringVar(&metricsPusher.Job, "job", "", "Job to use when pushing metrics to cluster")
 	flags.DurationVar(&metricsPusher.Frequency, "frequency", 30*time.Second, "Frequency with which to push metrics")
 	return cmd
 }

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -677,6 +677,24 @@ spec:
                   fieldPath: spec.nodeName
             - name: EXCLUDE_MANIFESTS
               value: internal-openshift-hosted
+{{ if .ROKSMetricsImage }}
+        - name: metrics-pusher
+          image: {{ .ROKSMetricsImage }}
+          imagePullPolicy: Always
+          command:
+            - "metrics-pusher"
+          args:
+            - "--destination-path=/api/v1/namespaces/openshift-roks-metrics/services/push-gateway:http/proxy/metrics"
+            - "--kubeconfig=/etc/openshift/kubeconfig/kubeconfig"
+            - "--job=cluster-version-operator"
+            - "--frequency=30s"
+            - "--source-url=http://localhost:9099/metrics"
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/openshift/kubeconfig
+              name: kubeconfig
+              readOnly: true
+{{ end }}
       volumes:
         - name: work
           emptyDir: {}
@@ -3368,8 +3386,7 @@ spec:
   - interval: 30s
     path: /metrics
     port: http
-    scheme: http
-  jobLabel: component
+    honorLabels: true
   selector:
     matchLabels:
       app: metrics-push-gateway

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -66,6 +66,8 @@
 // assets/registry/cluster-imageregistry-config.yaml
 // assets/roks-metrics/roks-metrics-00-namespace.yaml
 // assets/roks-metrics/roks-metrics-deployment.yaml
+// assets/roks-metrics/roks-metrics-push-gateway-service.yaml
+// assets/roks-metrics/roks-metrics-push-gateway-servicemonitor.yaml
 // assets/roks-metrics/roks-metrics-rbac.yaml
 // assets/roks-metrics/roks-metrics-service.yaml
 // assets/roks-metrics/roks-metrics-serviceaccount.yaml
@@ -3291,6 +3293,14 @@ spec:
         volumeMounts:
         - name: serving-cert
           mountPath: /var/run/secrets/serving-cert
+      - name: push-gateway
+        image: {{ .ROKSMetricsImage }}
+        imagePullPolicy: Always
+        command:
+        - pushgateway
+        ports:
+        - containerPort: 9091
+          name: gateway
       serviceAccountName: roks-metrics 
       volumes:
       - name: serving-cert
@@ -3311,6 +3321,71 @@ func roksMetricsRoksMetricsDeploymentYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "roks-metrics/roks-metrics-deployment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _roksMetricsRoksMetricsPushGatewayServiceYaml = []byte(`apiVersion: v1
+kind: Service
+metadata:
+  name: push-gateway
+  namespace: openshift-roks-metrics
+  labels:
+    app: metrics-push-gateway
+spec:
+  ports:
+  - name: http
+    port: 9091
+    protocol: TCP
+    targetPort: gateway
+  selector:
+    app: metrics
+  type: ClusterIP
+`)
+
+func roksMetricsRoksMetricsPushGatewayServiceYamlBytes() ([]byte, error) {
+	return _roksMetricsRoksMetricsPushGatewayServiceYaml, nil
+}
+
+func roksMetricsRoksMetricsPushGatewayServiceYaml() (*asset, error) {
+	bytes, err := roksMetricsRoksMetricsPushGatewayServiceYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "roks-metrics/roks-metrics-push-gateway-service.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _roksMetricsRoksMetricsPushGatewayServicemonitorYaml = []byte(`apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: roks-metrics-push-gateway
+  namespace: openshift-roks-metrics
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: http
+    scheme: http
+  jobLabel: component
+  selector:
+    matchLabels:
+      app: metrics-push-gateway
+`)
+
+func roksMetricsRoksMetricsPushGatewayServicemonitorYamlBytes() ([]byte, error) {
+	return _roksMetricsRoksMetricsPushGatewayServicemonitorYaml, nil
+}
+
+func roksMetricsRoksMetricsPushGatewayServicemonitorYaml() (*asset, error) {
+	bytes, err := roksMetricsRoksMetricsPushGatewayServicemonitorYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "roks-metrics/roks-metrics-push-gateway-servicemonitor.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3761,6 +3836,8 @@ var _bindata = map[string]func() (*asset, error){
 	"registry/cluster-imageregistry-config.yaml":                                         registryClusterImageregistryConfigYaml,
 	"roks-metrics/roks-metrics-00-namespace.yaml":                                        roksMetricsRoksMetrics00NamespaceYaml,
 	"roks-metrics/roks-metrics-deployment.yaml":                                          roksMetricsRoksMetricsDeploymentYaml,
+	"roks-metrics/roks-metrics-push-gateway-service.yaml":                                roksMetricsRoksMetricsPushGatewayServiceYaml,
+	"roks-metrics/roks-metrics-push-gateway-servicemonitor.yaml":                         roksMetricsRoksMetricsPushGatewayServicemonitorYaml,
 	"roks-metrics/roks-metrics-rbac.yaml":                                                roksMetricsRoksMetricsRbacYaml,
 	"roks-metrics/roks-metrics-service.yaml":                                             roksMetricsRoksMetricsServiceYaml,
 	"roks-metrics/roks-metrics-serviceaccount.yaml":                                      roksMetricsRoksMetricsServiceaccountYaml,
@@ -3897,12 +3974,14 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"cluster-imageregistry-config.yaml": {registryClusterImageregistryConfigYaml, map[string]*bintree{}},
 	}},
 	"roks-metrics": {nil, map[string]*bintree{
-		"roks-metrics-00-namespace.yaml":   {roksMetricsRoksMetrics00NamespaceYaml, map[string]*bintree{}},
-		"roks-metrics-deployment.yaml":     {roksMetricsRoksMetricsDeploymentYaml, map[string]*bintree{}},
-		"roks-metrics-rbac.yaml":           {roksMetricsRoksMetricsRbacYaml, map[string]*bintree{}},
-		"roks-metrics-service.yaml":        {roksMetricsRoksMetricsServiceYaml, map[string]*bintree{}},
-		"roks-metrics-serviceaccount.yaml": {roksMetricsRoksMetricsServiceaccountYaml, map[string]*bintree{}},
-		"roks-metrics-servicemonitor.yaml": {roksMetricsRoksMetricsServicemonitorYaml, map[string]*bintree{}},
+		"roks-metrics-00-namespace.yaml":                {roksMetricsRoksMetrics00NamespaceYaml, map[string]*bintree{}},
+		"roks-metrics-deployment.yaml":                  {roksMetricsRoksMetricsDeploymentYaml, map[string]*bintree{}},
+		"roks-metrics-push-gateway-service.yaml":        {roksMetricsRoksMetricsPushGatewayServiceYaml, map[string]*bintree{}},
+		"roks-metrics-push-gateway-servicemonitor.yaml": {roksMetricsRoksMetricsPushGatewayServicemonitorYaml, map[string]*bintree{}},
+		"roks-metrics-rbac.yaml":                        {roksMetricsRoksMetricsRbacYaml, map[string]*bintree{}},
+		"roks-metrics-service.yaml":                     {roksMetricsRoksMetricsServiceYaml, map[string]*bintree{}},
+		"roks-metrics-serviceaccount.yaml":              {roksMetricsRoksMetricsServiceaccountYaml, map[string]*bintree{}},
+		"roks-metrics-servicemonitor.yaml":              {roksMetricsRoksMetricsServicemonitorYaml, map[string]*bintree{}},
 	}},
 	"user-manifests-bootstrapper": {nil, map[string]*bintree{
 		"user-manifest-template.yaml":          {userManifestsBootstrapperUserManifestTemplateYaml, map[string]*bintree{}},

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -66,6 +66,7 @@
 // assets/registry/cluster-imageregistry-config.yaml
 // assets/roks-metrics/roks-metrics-00-namespace.yaml
 // assets/roks-metrics/roks-metrics-deployment.yaml
+// assets/roks-metrics/roks-metrics-push-gateway-deployment.yaml
 // assets/roks-metrics/roks-metrics-push-gateway-service.yaml
 // assets/roks-metrics/roks-metrics-push-gateway-servicemonitor.yaml
 // assets/roks-metrics/roks-metrics-rbac.yaml
@@ -684,9 +685,8 @@ spec:
           command:
             - "metrics-pusher"
           args:
-            - "--destination-path=/api/v1/namespaces/openshift-roks-metrics/services/push-gateway:http/proxy/metrics"
+            - "--destination-path=/api/v1/namespaces/openshift-roks-metrics/services/push-gateway:http/proxy/metrics/job/cluster-version-operator"
             - "--kubeconfig=/etc/openshift/kubeconfig/kubeconfig"
-            - "--job=cluster-version-operator"
             - "--frequency=30s"
             - "--source-url=http://localhost:9099/metrics"
           terminationMessagePolicy: FallbackToLogsOnError
@@ -3311,14 +3311,6 @@ spec:
         volumeMounts:
         - name: serving-cert
           mountPath: /var/run/secrets/serving-cert
-      - name: push-gateway
-        image: {{ .ROKSMetricsImage }}
-        imagePullPolicy: Always
-        command:
-        - pushgateway
-        ports:
-        - containerPort: 9091
-          name: gateway
       serviceAccountName: roks-metrics 
       volumes:
       - name: serving-cert
@@ -3343,21 +3335,76 @@ func roksMetricsRoksMetricsDeploymentYaml() (*asset, error) {
 	return a, nil
 }
 
+var _roksMetricsRoksMetricsPushGatewayDeploymentYaml = []byte(`kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: push-gateway
+  namespace: openshift-roks-metrics
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: push-gateway
+  template:
+    metadata:
+      labels:
+        app: push-gateway
+{{ if .RestartDate }}
+      annotations:
+        openshift.io/restartedAt: "{{ .RestartDate }}"
+{{ end }}
+    spec:
+      tolerations:
+        - key: "multi-az-worker"
+          operator: "Equal"
+          value: "true"
+          effect: NoSchedule
+      containers:
+      - name: push-gateway
+        image: {{ .ROKSMetricsImage }}
+        imagePullPolicy: Always
+        command:
+        - pushgateway
+        ports:
+        - containerPort: 9091
+          name: http
+`)
+
+func roksMetricsRoksMetricsPushGatewayDeploymentYamlBytes() ([]byte, error) {
+	return _roksMetricsRoksMetricsPushGatewayDeploymentYaml, nil
+}
+
+func roksMetricsRoksMetricsPushGatewayDeploymentYaml() (*asset, error) {
+	bytes, err := roksMetricsRoksMetricsPushGatewayDeploymentYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "roks-metrics/roks-metrics-push-gateway-deployment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _roksMetricsRoksMetricsPushGatewayServiceYaml = []byte(`apiVersion: v1
 kind: Service
 metadata:
   name: push-gateway
   namespace: openshift-roks-metrics
   labels:
-    app: metrics-push-gateway
+    app: push-gateway
 spec:
   ports:
   - name: http
     port: 9091
     protocol: TCP
-    targetPort: gateway
+    targetPort: http
   selector:
-    app: metrics
+    app: push-gateway
   type: ClusterIP
 `)
 
@@ -3389,7 +3436,7 @@ spec:
     honorLabels: true
   selector:
     matchLabels:
-      app: metrics-push-gateway
+      app: push-gateway
 `)
 
 func roksMetricsRoksMetricsPushGatewayServicemonitorYamlBytes() ([]byte, error) {
@@ -3853,6 +3900,7 @@ var _bindata = map[string]func() (*asset, error){
 	"registry/cluster-imageregistry-config.yaml":                                         registryClusterImageregistryConfigYaml,
 	"roks-metrics/roks-metrics-00-namespace.yaml":                                        roksMetricsRoksMetrics00NamespaceYaml,
 	"roks-metrics/roks-metrics-deployment.yaml":                                          roksMetricsRoksMetricsDeploymentYaml,
+	"roks-metrics/roks-metrics-push-gateway-deployment.yaml":                             roksMetricsRoksMetricsPushGatewayDeploymentYaml,
 	"roks-metrics/roks-metrics-push-gateway-service.yaml":                                roksMetricsRoksMetricsPushGatewayServiceYaml,
 	"roks-metrics/roks-metrics-push-gateway-servicemonitor.yaml":                         roksMetricsRoksMetricsPushGatewayServicemonitorYaml,
 	"roks-metrics/roks-metrics-rbac.yaml":                                                roksMetricsRoksMetricsRbacYaml,
@@ -3993,6 +4041,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"roks-metrics": {nil, map[string]*bintree{
 		"roks-metrics-00-namespace.yaml":                {roksMetricsRoksMetrics00NamespaceYaml, map[string]*bintree{}},
 		"roks-metrics-deployment.yaml":                  {roksMetricsRoksMetricsDeploymentYaml, map[string]*bintree{}},
+		"roks-metrics-push-gateway-deployment.yaml":     {roksMetricsRoksMetricsPushGatewayDeploymentYaml, map[string]*bintree{}},
 		"roks-metrics-push-gateway-service.yaml":        {roksMetricsRoksMetricsPushGatewayServiceYaml, map[string]*bintree{}},
 		"roks-metrics-push-gateway-servicemonitor.yaml": {roksMetricsRoksMetricsPushGatewayServicemonitorYaml, map[string]*bintree{}},
 		"roks-metrics-rbac.yaml":                        {roksMetricsRoksMetricsRbacYaml, map[string]*bintree{}},

--- a/pkg/metrics_pusher/pusher.go
+++ b/pkg/metrics_pusher/pusher.go
@@ -1,0 +1,87 @@
+package metrics_pusher
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type MetricsPusher struct {
+	Log             logr.Logger
+	SourceURL       string
+	DestinationPath string
+	Kubeconfig      string
+	Job             string
+	Frequency       time.Duration
+
+	restClient rest.Interface
+	pushPath   []string
+}
+
+const (
+	requestTimeout = 2 * time.Minute
+)
+
+func (p *MetricsPusher) Run() error {
+	var err error
+	p.restClient, err = p.getRESTClient()
+	if err != nil {
+		p.Log.Error(err, "Failed to get REST client for target")
+		return err
+	}
+	p.pushPath = p.getPushPath()
+	p.Log.Info("Polling for metrics", "from", p.SourceURL, "to", p.DestinationPath)
+	wait.Forever(p.pushMetrics, p.Frequency)
+	return nil
+}
+
+func (p *MetricsPusher) pushMetrics() {
+	resp, err := http.Get(p.SourceURL)
+	if err != nil {
+		p.Log.Error(err, "failed to fetch metrics from source")
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		p.Log.Error(fmt.Errorf("Status: %s (%d)", resp.Status, resp.StatusCode), "Unexpected status from source URL")
+		return
+	}
+	metricsBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		p.Log.Error(err, "Failed to read metrics body from source URL")
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+	p.Log.Info("Pushing metrics")
+	result := p.restClient.Post().AbsPath(p.pushPath...).Body(metricsBody).Do(ctx)
+	if result.Error() != nil {
+		p.Log.Error(result.Error(), "failed to post metrics")
+		return
+	}
+}
+
+func (p *MetricsPusher) getPushPath() []string {
+	parts := strings.Split(p.DestinationPath, "/")
+	parts = append(parts, "job", p.Job)
+	return parts
+}
+
+func (p *MetricsPusher) getRESTClient() (rest.Interface, error) {
+	kubeconfig := clientcmd.GetConfigFromFileOrDie(p.Kubeconfig)
+	clientConfig := clientcmd.NewDefaultClientConfig(*kubeconfig, &clientcmd.ConfigOverrides{})
+	restConfig, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfigOrDie(restConfig).CoreV1().RESTClient(), nil
+}

--- a/pkg/metrics_pusher/pusher.go
+++ b/pkg/metrics_pusher/pusher.go
@@ -21,7 +21,6 @@ type MetricsPusher struct {
 	SourceURL       string
 	DestinationPath string
 	Kubeconfig      string
-	Job             string
 	Frequency       time.Duration
 
 	restClient rest.Interface
@@ -72,7 +71,6 @@ func (p *MetricsPusher) pushMetrics() {
 
 func (p *MetricsPusher) getPushPath() []string {
 	parts := strings.Split(p.DestinationPath, "/")
-	parts = append(parts, "job", p.Job)
 	return parts
 }
 

--- a/pkg/render/manifests.go
+++ b/pkg/render/manifests.go
@@ -189,6 +189,8 @@ func (c *clusterManifestContext) roksMetrics() {
 		"roks-metrics/roks-metrics-service.yaml",
 		"roks-metrics/roks-metrics-serviceaccount.yaml",
 		"roks-metrics/roks-metrics-servicemonitor.yaml",
+		"roks-metrics/roks-metrics-push-gateway-service.yaml",
+		"roks-metrics/roks-metrics-push-gateway-servicemonitor.yaml",
 	)
 }
 

--- a/pkg/render/manifests.go
+++ b/pkg/render/manifests.go
@@ -189,6 +189,7 @@ func (c *clusterManifestContext) roksMetrics() {
 		"roks-metrics/roks-metrics-service.yaml",
 		"roks-metrics/roks-metrics-serviceaccount.yaml",
 		"roks-metrics/roks-metrics-servicemonitor.yaml",
+		"roks-metrics/roks-metrics-push-gateway-deployment.yaml",
 		"roks-metrics/roks-metrics-push-gateway-service.yaml",
 		"roks-metrics/roks-metrics-push-gateway-servicemonitor.yaml",
 	)


### PR DESCRIPTION
Adds push gateway to ROKS metrics image
Adds manifests to run push gateway inside child cluster and sets up a servicemonitor for it.
Creates a metrics-pusher utility to periodically push metrics produced by a source URL and into a given path in a cluster
Adds the metrics-pusher sidecar container to the CVO pod so that it can push metrics into the child cluster.