### PR TITLE
Include machineconfig/machineconfigpool CRD manifests in bootstrap manifests

### DIFF
--- a/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
+++ b/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
@@ -42,6 +42,8 @@ spec:
           # Exclude the CVO deployment manifest
           rm /tmp/output/manifests/0000_00_cluster-version-operator*deployment.yaml
           cp /tmp/output/manifests/* /work
+          # Add machineconfig CRDs to prevent upgrade getting stuck
+          cp /release-manifests/*machine-config-operator*machineconfig*.crd.yaml /work
       volumeMounts:
         - mountPath: /work
           name: work

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3573,6 +3573,8 @@ spec:
           # Exclude the CVO deployment manifest
           rm /tmp/output/manifests/0000_00_cluster-version-operator*deployment.yaml
           cp /tmp/output/manifests/* /work
+          # Add machineconfig CRDs to prevent upgrade getting stuck
+          cp /release-manifests/*machine-config-operator*machineconfig*.crd.yaml /work
       volumeMounts:
         - mountPath: /work
           name: work


### PR DESCRIPTION
Resolves issue where CVO stops applying manifests during an upgrade because the machineconfig and machineconfigpool CRD manifests are not present.