### PR TITLE
Update feature flags to mirror OCP

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -8,9 +8,13 @@ import (
 func NewClusterParams() *ClusterParams {
 	p := &ClusterParams{}
 	p.DefaultFeatureGates = []string{
+		"APIPriorityAndFairness=true",
 		"SupportPodPidsLimit=true",
-		"LocalStorageCapacityIsolation=false",
 		"RotateKubeletServerCertificate=true",
+		"LegacyNodeRoleBehavior=false",
+		"NodeDisruptionExclusion=true",
+		"SCTPSupport=true",
+		"ServiceNodeExclusion=true",
 	}
 	p.ImageRegistryHTTPSecret = uuid.New().String()
 	return p


### PR DESCRIPTION
Default flags have changed in OCP since 4.3, this updates them to what we're currently using in 4.5
See https://github.com/openshift/machine-config-operator/blob/release-4.5/templates/master/01-master-kubelet/_base/files/kubelet.yaml#L31-L36
and https://github.com/openshift/api/blob/0a191b5b9bb0ff4bf39e44be0fb4ffd7381766d3/config/v1/types_feature.go#L114-L124