### PR TITLE
Support customization of control plane liveness and readiness probes

### DIFF
--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -70,17 +70,44 @@ spec:
         - "--encryption-provider-config=/etc/kubernetes/kms-config/config.yaml"
 {{ end }}
         workingDir: /var/log/kube-apiserver
+{{- if .ApiserverLivenessProbe }}
+{{- $probe := .ApiserverLivenessProbe }}
+        livenessProbe:
+          httpGet:
+            scheme: {{ or $probe.HttpGet.Scheme "HTTPS" }}
+            port: {{ or $probe.HttpGet.Port .InternalAPIPort }}
+            path: {{ or $probe.HttpGet.Path "livez?exclude=etcd" }}
+          initialDelaySeconds: {{ or $probe.InitialDelaySeconds 10 }}
+          periodSeconds: {{ or $probe.PeriodSeconds 10 }}
+          timeoutSeconds: {{ or $probe.TimeoutSeconds 1 }}
+          failureThreshold: {{ or $probe.FailureThreshold 3 }}
+          successThreshold: {{ or $probe.SuccessThreshold 1 }}
+{{- else }}
         livenessProbe:
           httpGet:
             scheme: HTTPS
             port: {{ .InternalAPIPort }}
-{{ if .ApiserverLivenessPath }}
+{{- if .ApiserverLivenessPath }}
             path: "{{ .ApiserverLivenessPath }}"
-{{ else }}
+{{- else }}
             path: livez
-{{ end }}
+{{- end }}
           initialDelaySeconds: 45
           timeoutSeconds: 10
+{{- end }}
+{{- if .ApiserverReadinessProbe }}
+{{- $probe := .ApiserverReadinessProbe }}
+        readinessProbe:
+          httpGet:
+            scheme: {{ or $probe.HttpGet.Scheme "HTTPS" }}
+            port: {{ or $probe.HttpGet.Port .InternalAPIPort }}
+            path: {{ or $probe.HttpGet.Path "readyz" }}
+          initialDelaySeconds: {{ or $probe.InitialDelaySeconds 10 }}
+          periodSeconds: {{ or $probe.PeriodSeconds 10 }}
+          timeoutSeconds: {{ or $probe.TimeoutSeconds 1 }}
+          failureThreshold: {{ or $probe.FailureThreshold 3 }}
+          successThreshold: {{ or $probe.SuccessThreshold 1 }}
+{{- else }}
         readinessProbe:
           httpGet:
             scheme: HTTPS
@@ -88,6 +115,7 @@ spec:
             path: readyz
           initialDelaySeconds: 10
           timeoutSeconds: 10
+{{- end }}
 {{ if .KubeAPIServerResources }}
         resources:{{ range .KubeAPIServerResources }}{{ range .ResourceRequest }}
           requests: {{ if .CPU }}
@@ -131,6 +159,19 @@ spec:
 {{ end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+{{- if .KMSLivenessProbe }}
+{{- $probe := .KMSLivenessProbe }}
+        livenessProbe:
+          httpGet:
+            scheme: {{ or $probe.HttpGet.Scheme "HTTP" }}
+            port: {{ or $probe.HttpGet.Port 8081 }}
+            path: {{ or $probe.HttpGet.Path "healthz/liveness" }}
+          initialDelaySeconds: {{ or $probe.InitialDelaySeconds 10 }}
+          periodSeconds: {{ or $probe.PeriodSeconds 10 }}
+          timeoutSeconds: {{ or $probe.TimeoutSeconds 1 }}
+          failureThreshold: {{ or $probe.FailureThreshold 3 }}
+          successThreshold: {{ or $probe.SuccessThreshold 1 }}
+{{- else }}
         livenessProbe:
           httpGet:
             path: /healthz/liveness
@@ -141,6 +182,7 @@ spec:
           successThreshold: 1
           failureThreshold: 3
           timeoutSeconds: 160
+{{- end }}
         env:
         - name: REGION
           value: {{ .KPRegion }}

--- a/assets/kube-controller-manager/kube-controller-manager-deployment.yaml
+++ b/assets/kube-controller-manager/kube-controller-manager-deployment.yaml
@@ -74,6 +74,19 @@ spec:
             cpu: {{ .CPU }}{{ end }}{{ if .Memory }}
             memory: {{ .Memory }}{{ end }}{{ end }}{{ end }}
 {{ end }}
+{{- if .ControllerManagerLivenessProbe }}
+{{- $probe := .ControllerManagerLivenessProbe }}
+        livenessProbe:
+          httpGet:
+            scheme: {{ or $probe.HttpGet.Scheme "HTTPS" }}
+            port: {{ or $probe.HttpGet.Port 10257 }}
+            path: {{ or $probe.HttpGet.Path "healthz" }}
+          initialDelaySeconds: {{ or $probe.InitialDelaySeconds 10 }}
+          periodSeconds: {{ or $probe.PeriodSeconds 10 }}
+          timeoutSeconds: {{ or $probe.TimeoutSeconds 1 }}
+          failureThreshold: {{ or $probe.FailureThreshold 3 }}
+          successThreshold: {{ or $probe.SuccessThreshold 1 }}
+{{- end }}
         volumeMounts:
         - mountPath: /etc/kubernetes/cmconfig
           name: cmconfig

--- a/assets/kube-scheduler/kube-scheduler-deployment.yaml
+++ b/assets/kube-scheduler/kube-scheduler-deployment.yaml
@@ -81,6 +81,19 @@ spec:
             cpu: {{ .CPU }}{{ end }}{{ if .Memory }}
             memory: {{ .Memory }}{{ end }}{{ end }}{{ end }}
 {{ end }}
+{{- if .SchedulerLivenessProbe }}
+{{- $probe := .SchedulerLivenessProbe }}
+        livenessProbe:
+          httpGet:
+            scheme: {{ or $probe.HttpGet.Scheme "HTTPS" }}
+            port: {{ or $probe.HttpGet.Port 10259 }}
+            path: {{ or $probe.HttpGet.Path "healthz" }}
+          initialDelaySeconds: {{ or $probe.InitialDelaySeconds 10 }}
+          periodSeconds: {{ or $probe.PeriodSeconds 10 }}
+          timeoutSeconds: {{ or $probe.TimeoutSeconds 1 }}
+          failureThreshold: {{ or $probe.FailureThreshold 3 }}
+          successThreshold: {{ or $probe.SuccessThreshold 1 }}
+{{- end }}
         volumeMounts:
         - mountPath: /etc/kubernetes/secret
           name: secret

--- a/cluster.yaml.example
+++ b/cluster.yaml.example
@@ -144,7 +144,31 @@ kpRegion: us-south
 apiServerAuditEnabled: true
 restartDate: "2017-07-27T16:39:00Z"
 extraFeatureGates: [ExpandInUsePersistentVolumes=true]
-apiserverLivenessPath: livez?exclude=etcd
+# apiserverLivenessPath: livez?exclude=etcd
+apiserverLivenessProbe:
+  initialDelaySeconds: 300
+  periodSeconds: 10
+  timeoutSeconds: 160
+  failureThreshold: 6
+  successThreshold: 1
+apiserverReadinessProbe:
+  initialDelaySeconds: 15
+  periodSeconds: 30
+  timeoutSeconds: 120
+  failureThreshold: 6
+  successThreshold: 1
+kmsLivenessProbe:
+  initialDelaySeconds: 120
+  periodSeconds: 300
+  timeoutSeconds: 160
+  failureThreshold: 3
+  successThreshold: 1
+controllerManagerLivenessProbe:
+  initialDelaySeconds: 300
+  timeoutSeconds: 160
+schedulerLivenessProbe:
+  initialDelaySeconds: 300
+  timeoutSeconds: 160
 controlPlaneOperatorImage: registry.svc.ci.openshift.org/ibm-roks/ibm-roks-4.4:control-plane-operator
 controlPlaneOperatorSecurity: 1001
 masterPriorityClass: ''

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -56,11 +56,31 @@ type ClusterParams struct {
 	DefaultFeatureGates                 []string
 	PlatformType                        string `json:"platformType"`
 	EndpointPublishingStrategyScope     string `json:"endpointPublishingStrategyScope"`
+	ApiserverLivenessProbe              *Probe `json:"apiserverLivenessProbe",omitempty`
+	ApiserverReadinessProbe             *Probe `json:"apiserverReadinessProbe",omitempty`
+	ControllerManagerLivenessProbe      *Probe `json:"controllerManagerLivenessProbe",omitempty`
+	SchedulerLivenessProbe              *Probe `json:"schedulerLivenessProbe",omitempty`
+	KMSLivenessProbe                    *Probe `json:"kmsLivenessProbe",omitempty`
 }
 
 type NamedCert struct {
 	NamedCertPrefix string `json:"namedCertPrefix"`
 	NamedCertDomain string `json:"namedCertDomain"`
+}
+
+type HttpGetAction struct {
+	Path   string `json:"path"`
+	Port   uint   `json:"port"`
+	Scheme string `json:"scheme"`
+}
+
+type Probe struct {
+	HttpGet             HttpGetAction `json:"httpGet"`
+	InitialDelaySeconds uint          `json:"initialDelaySeconds"`
+	PeriodSeconds       uint          `json:"periodSeconds"`
+	TimeoutSeconds      uint          `json:"timeoutSeconds"`
+	FailureThreshold    uint          `json:"failureThreshold"`
+	SuccessThreshold    uint          `json:"successThreshold"`
 }
 
 type ResourceRequirements struct {

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1235,17 +1235,44 @@ spec:
         - "--encryption-provider-config=/etc/kubernetes/kms-config/config.yaml"
 {{ end }}
         workingDir: /var/log/kube-apiserver
+{{- if .ApiserverLivenessProbe }}
+{{- $probe := .ApiserverLivenessProbe }}
+        livenessProbe:
+          httpGet:
+            scheme: {{ or $probe.HttpGet.Scheme "HTTPS" }}
+            port: {{ or $probe.HttpGet.Port .InternalAPIPort }}
+            path: {{ or $probe.HttpGet.Path "livez?exclude=etcd" }}
+          initialDelaySeconds: {{ or $probe.InitialDelaySeconds 10 }}
+          periodSeconds: {{ or $probe.PeriodSeconds 10 }}
+          timeoutSeconds: {{ or $probe.TimeoutSeconds 1 }}
+          failureThreshold: {{ or $probe.FailureThreshold 3 }}
+          successThreshold: {{ or $probe.SuccessThreshold 1 }}
+{{- else }}
         livenessProbe:
           httpGet:
             scheme: HTTPS
             port: {{ .InternalAPIPort }}
-{{ if .ApiserverLivenessPath }}
+{{- if .ApiserverLivenessPath }}
             path: "{{ .ApiserverLivenessPath }}"
-{{ else }}
+{{- else }}
             path: livez
-{{ end }}
+{{- end }}
           initialDelaySeconds: 45
           timeoutSeconds: 10
+{{- end }}
+{{- if .ApiserverReadinessProbe }}
+{{- $probe := .ApiserverReadinessProbe }}
+        readinessProbe:
+          httpGet:
+            scheme: {{ or $probe.HttpGet.Scheme "HTTPS" }}
+            port: {{ or $probe.HttpGet.Port .InternalAPIPort }}
+            path: {{ or $probe.HttpGet.Path "readyz" }}
+          initialDelaySeconds: {{ or $probe.InitialDelaySeconds 10 }}
+          periodSeconds: {{ or $probe.PeriodSeconds 10 }}
+          timeoutSeconds: {{ or $probe.TimeoutSeconds 1 }}
+          failureThreshold: {{ or $probe.FailureThreshold 3 }}
+          successThreshold: {{ or $probe.SuccessThreshold 1 }}
+{{- else }}
         readinessProbe:
           httpGet:
             scheme: HTTPS
@@ -1253,6 +1280,7 @@ spec:
             path: readyz
           initialDelaySeconds: 10
           timeoutSeconds: 10
+{{- end }}
 {{ if .KubeAPIServerResources }}
         resources:{{ range .KubeAPIServerResources }}{{ range .ResourceRequest }}
           requests: {{ if .CPU }}
@@ -1296,6 +1324,19 @@ spec:
 {{ end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+{{- if .KMSLivenessProbe }}
+{{- $probe := .KMSLivenessProbe }}
+        livenessProbe:
+          httpGet:
+            scheme: {{ or $probe.HttpGet.Scheme "HTTP" }}
+            port: {{ or $probe.HttpGet.Port 8081 }}
+            path: {{ or $probe.HttpGet.Path "healthz/liveness" }}
+          initialDelaySeconds: {{ or $probe.InitialDelaySeconds 10 }}
+          periodSeconds: {{ or $probe.PeriodSeconds 10 }}
+          timeoutSeconds: {{ or $probe.TimeoutSeconds 1 }}
+          failureThreshold: {{ or $probe.FailureThreshold 3 }}
+          successThreshold: {{ or $probe.SuccessThreshold 1 }}
+{{- else }}
         livenessProbe:
           httpGet:
             path: /healthz/liveness
@@ -1306,6 +1347,7 @@ spec:
           successThreshold: 1
           failureThreshold: 3
           timeoutSeconds: 160
+{{- end }}
         env:
         - name: REGION
           value: {{ .KPRegion }}
@@ -1724,6 +1766,19 @@ spec:
             cpu: {{ .CPU }}{{ end }}{{ if .Memory }}
             memory: {{ .Memory }}{{ end }}{{ end }}{{ end }}
 {{ end }}
+{{- if .ControllerManagerLivenessProbe }}
+{{- $probe := .ControllerManagerLivenessProbe }}
+        livenessProbe:
+          httpGet:
+            scheme: {{ or $probe.HttpGet.Scheme "HTTPS" }}
+            port: {{ or $probe.HttpGet.Port 10257 }}
+            path: {{ or $probe.HttpGet.Path "healthz" }}
+          initialDelaySeconds: {{ or $probe.InitialDelaySeconds 10 }}
+          periodSeconds: {{ or $probe.PeriodSeconds 10 }}
+          timeoutSeconds: {{ or $probe.TimeoutSeconds 1 }}
+          failureThreshold: {{ or $probe.FailureThreshold 3 }}
+          successThreshold: {{ or $probe.SuccessThreshold 1 }}
+{{- end }}
         volumeMounts:
         - mountPath: /etc/kubernetes/cmconfig
           name: cmconfig
@@ -1923,6 +1978,19 @@ spec:
             cpu: {{ .CPU }}{{ end }}{{ if .Memory }}
             memory: {{ .Memory }}{{ end }}{{ end }}{{ end }}
 {{ end }}
+{{- if .SchedulerLivenessProbe }}
+{{- $probe := .SchedulerLivenessProbe }}
+        livenessProbe:
+          httpGet:
+            scheme: {{ or $probe.HttpGet.Scheme "HTTPS" }}
+            port: {{ or $probe.HttpGet.Port 10259 }}
+            path: {{ or $probe.HttpGet.Path "healthz" }}
+          initialDelaySeconds: {{ or $probe.InitialDelaySeconds 10 }}
+          periodSeconds: {{ or $probe.PeriodSeconds 10 }}
+          timeoutSeconds: {{ or $probe.TimeoutSeconds 1 }}
+          failureThreshold: {{ or $probe.FailureThreshold 3 }}
+          successThreshold: {{ or $probe.SuccessThreshold 1 }}
+{{- end }}
         volumeMounts:
         - mountPath: /etc/kubernetes/secret
           name: secret


### PR DESCRIPTION
Allows full customization of http get liveness and readiness probes ala:
```
apiserverLivenessProbe:
  httpGet:
    path: livez?exclude=etcd
  initialDelaySeconds: 300
  periodSeconds: 10
  timeoutSeconds: 160
  failureThreshold: 6
  successThreshold: 1
```
The httpGet path, port and scheme have defaults appropriate to each
service. The associated times and thresholds use the Kubernetes defaults.
The following probes are currently provided:
- apiserver liveness and readiness
- kms liveness
- scheduler liveness
- controller-manager liveness

Without changes to the cluster.yaml the existing ROKS configuration
is used.