### PR TITLE
Portieris admission controller support

### DIFF
--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -234,6 +234,40 @@ spec:
             name: kubeconfig
             readOnly: true
 {{- end }}
+{{ if .PortierisEnabled }}
+      - name: portieris
+        image: {{ .PortierisImage }}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8000
+          name: http
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        livenessProbe:
+          httpGet:
+            port: 8000
+            path: "/health/liveness"
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            port: 8000
+            path: "/health/readiness"
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/secret/kubeconfig
+        volumeMounts:
+        - mountPath: /etc/kubernetes/secret/
+          name: secret
+        - mountPath: /etc/certs
+          name: portieris-certs
+{{ end }}
       volumes:
       - secret:
           secretName: kube-apiserver
@@ -270,4 +304,10 @@ spec:
           secretName: kp-wdek-secret
           optional: true
           defaultMode: 0400
+{{ end }}
+{{ if .PortierisEnabled }}
+      - name: portieris-certs
+        secret:
+          defaultMode: 420
+          secretName: portieris-certs
 {{ end }}

--- a/cluster.yaml.example
+++ b/cluster.yaml.example
@@ -173,3 +173,5 @@ controlPlaneOperatorImage: registry.svc.ci.openshift.org/ibm-roks/ibm-roks-4.4:c
 controlPlaneOperatorSecurity: 1001
 masterPriorityClass: ''
 roksMetricsImage: registry.svc.ci.openshift.org/hypershift-toolkit/ibm-roks-4.6:roks-metrics
+portierisEnabled: false
+portierisImage: ''

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -53,6 +53,8 @@ type ClusterParams struct {
 	ControlPlaneOperatorSecurity        string                 `json:"controlPlaneOperatorSecurity"`
 	MasterPriorityClass                 string                 `json:"masterPriorityClass"`
 	ApiserverLivenessPath               string                 `json:"apiserverLivenessPath"`
+	PortierisEnabled                    bool                   `json:"portierisEnabled"`
+	PortierisImage                      string                 `json:"portierisImage"`
 	DefaultFeatureGates                 []string
 	PlatformType                        string `json:"platformType"`
 	EndpointPublishingStrategyScope     string `json:"endpointPublishingStrategyScope"`

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1359,6 +1359,40 @@ spec:
             name: kubeconfig
             readOnly: true
 {{- end }}
+{{ if .PortierisEnabled }}
+      - name: portieris
+        image: {{ .PortierisImage }}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8000
+          name: http
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        livenessProbe:
+          httpGet:
+            port: 8000
+            path: "/health/liveness"
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            port: 8000
+            path: "/health/readiness"
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/secret/kubeconfig
+        volumeMounts:
+        - mountPath: /etc/kubernetes/secret/
+          name: secret
+        - mountPath: /etc/certs
+          name: portieris-certs
+{{ end }}
       volumes:
       - secret:
           secretName: kube-apiserver
@@ -1395,6 +1429,12 @@ spec:
           secretName: kp-wdek-secret
           optional: true
           defaultMode: 0400
+{{ end }}
+{{ if .PortierisEnabled }}
+      - name: portieris-certs
+        secret:
+          defaultMode: 420
+          secretName: portieris-certs
 {{ end }}
 `)
 


### PR DESCRIPTION
Cluster image-security provided by the [Portieris](https://github.com/IBM/portieris) admission controller is an upcoming feature for IKS clusters.  These changes provide support for Openshift clusters.