### PR TITLE
Enable flow control APIs for priority and fairness

### DIFF
--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -48,6 +48,8 @@ apiServerArguments:
   - /etc/kubernetes/secret/service-account.key
   api-audiences:
   - https://kubernetes.default.svc
+  runtime-config:
+  - flowcontrol.apiserver.k8s.io/v1alpha1=true
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -948,6 +948,8 @@ apiServerArguments:
   - /etc/kubernetes/secret/service-account.key
   api-audiences:
   - https://kubernetes.default.svc
+  runtime-config:
+  - flowcontrol.apiserver.k8s.io/v1alpha1=true
 auditConfig:
   auditFilePath: "/var/log/kube-apiserver/audit.log"
   enabled: true


### PR DESCRIPTION
In 4.6 and later, the release payload contains manifests that will fail to apply if the flowcontrol API is not enabled in the Kube APIServer.