### PR TITLE
Use go 1.15 for toolkit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.14 as builder
+FROM openshift/origin-release:golang-1.15 as builder
 RUN mkdir -p /go/src/github.com/openshift/ibm-roks-toolkit
 WORKDIR /go/src/github.com/openshift/ibm-roks-toolkit
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/ibm-roks-toolkit
 
-go 1.14
+go 1.15
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
And earlier change bumped the go version for the cp-operator and metrics server.
Making the same change now for the toolkit.