### PR TITLE
[4.6] Use openshift/origin-base instead of ubi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/openshift/ibm-roks-toolkit
 COPY . .
 RUN go build -mod=vendor -o bin/ibm-roks github.com/openshift/ibm-roks-toolkit/cmd/ibm-roks
 
-FROM registry.access.redhat.com/ubi7/ubi
+FROM quay.io/openshift/origin-base:4.6
 
 COPY --from=builder /go/src/github.com/openshift/ibm-roks-toolkit/bin/ibm-roks /usr/bin
 

--- a/Dockerfile.cpoperator
+++ b/Dockerfile.cpoperator
@@ -5,7 +5,7 @@ WORKDIR /go/src/github.com/openshift/ibm-roks-toolkit
 COPY . .
 RUN go build -mod=vendor -o ./bin/control-plane-operator ./cmd/control-plane-operator/main.go
 
-FROM registry.access.redhat.com/ubi7/ubi
+FROM quay.io/openshift/origin-base:4.6
 RUN yum -y update && yum clean all
 COPY --from=builder /go/src/github.com/openshift/ibm-roks-toolkit/bin/control-plane-operator /usr/bin/control-plane-operator
 ENTRYPOINT /usr/bin/control-plane-operator

--- a/Dockerfile.metrics
+++ b/Dockerfile.metrics
@@ -9,8 +9,8 @@ RUN cd /tmp && \
     curl -OL https://github.com/prometheus/pushgateway/releases/download/v${PUSHGATEWAY_VERSION}/pushgateway-${PUSHGATEWAY_VERSION}.linux-amd64.tar.gz && \
     tar -xzf pushgateway-${PUSHGATEWAY_VERSION}.linux-amd64.tar.gz && \
     cp pushgateway-${PUSHGATEWAY_VERSION}.linux-amd64/pushgateway /pushgateway
-  
-FROM registry.access.redhat.com/ubi7/ubi
+
+FROM quay.io/openshift/origin-base:4.6
 RUN yum -y update && yum clean all
 COPY --from=builder /go/src/github.com/openshift/ibm-roks-toolkit/bin/roks-metrics /usr/bin/roks-metrics
 COPY --from=builder /go/src/github.com/openshift/ibm-roks-toolkit/bin/metrics-pusher /usr/bin/metrics-pusher


### PR DESCRIPTION
They seem to be functionally equivalent, and the new one is free of CVEs.