### PR TITLE
Changed runAsNonRoot to runAsUser for roks metrics

### DIFF
--- a/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
+++ b/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
@@ -83,10 +83,10 @@ spec:
 {{ if .ROKSMetricsImage }}
         - name: metrics-pusher
           image: {{ .ROKSMetricsImage }}
-{{- if .ROKSMetricsSecurityContext }}
-{{- $securityContext := .ROKSMetricsSecurityContext }}
+{{- if .ROKSMetricsSecurityContextMaster }}
+{{- $securityContext := .ROKSMetricsSecurityContextMaster }}
           securityContext:
-            runAsNonRoot: {{ $securityContext.RunAsNonRoot }}
+            runAsUser: {{ $securityContext.RunAsUser }}
 {{- end }}
           imagePullPolicy: Always
           command:

--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -229,10 +229,10 @@ spec:
 {{ end }}
 {{- if .ROKSMetricsImage }}
       - name: metrics-pusher
-{{- if .ROKSMetricsSecurityContext }}
-{{- $securityContext := .ROKSMetricsSecurityContext }}
+{{- if .ROKSMetricsSecurityContextMaster }}
+{{- $securityContext := .ROKSMetricsSecurityContextMaster }}
         securityContext:
-          runAsNonRoot: {{ $securityContext.RunAsNonRoot }}
+          runAsUser: {{ $securityContext.RunAsUser }}
 {{- end }}
         image: {{ .ROKSMetricsImage }}
         imagePullPolicy: Always

--- a/assets/roks-metrics/roks-metrics-deployment.yaml
+++ b/assets/roks-metrics/roks-metrics-deployment.yaml
@@ -29,8 +29,8 @@ spec:
           effect: NoSchedule
       containers:
       - name: metrics
-{{- if .ROKSMetricsSecurityContext }}
-{{- $securityContext := .ROKSMetricsSecurityContext }}
+{{- if .ROKSMetricsSecurityContextWorker }}
+{{- $securityContext := .ROKSMetricsSecurityContextWorker }}
         securityContext:
           runAsNonRoot: {{ $securityContext.RunAsNonRoot }}
 {{- end }}

--- a/assets/roks-metrics/roks-metrics-push-gateway-deployment.yaml
+++ b/assets/roks-metrics/roks-metrics-push-gateway-deployment.yaml
@@ -29,8 +29,8 @@ spec:
           effect: NoSchedule
       containers:
       - name: push-gateway
-{{- if .ROKSMetricsSecurityContext }}
-{{- $securityContext := .ROKSMetricsSecurityContext }}
+{{- if .ROKSMetricsSecurityContextWorker }}
+{{- $securityContext := .ROKSMetricsSecurityContextWorker }}
         securityContext:
           runAsNonRoot: {{ $securityContext.RunAsNonRoot }}
 {{- end }}

--- a/cluster.yaml.example
+++ b/cluster.yaml.example
@@ -187,7 +187,9 @@ controlPlaneOperatorSecurityContext:
   runAsUser: 1000
 masterPriorityClass: ''
 roksMetricsImage: registry.svc.ci.openshift.org/hypershift-toolkit/ibm-roks-4.6:roks-metrics
-roksMetricsSecurityContext:
+roksMetricsSecurityContextMaster:
+  runAsUser: 1000
+roksMetricsSecurityContextWorker:
   runAsNonRoot: true
 portierisEnabled: false
 portierisImage: ''

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -50,7 +50,8 @@ type ClusterParams struct {
 	ControlPlaneOperatorImage                 string                 `json:"controlPlaneOperatorImage"`
 	ControlPlaneOperatorControllers           []string               `json:"controlPlaneOperatorControllers"`
 	ROKSMetricsImage                          string                 `json:"roksMetricsImage"`
-	ROKSMetricsSecurityContext                *SecurityContext       `json:"roksMetricsSecurityContext"`
+	ROKSMetricsSecurityContextMaster          *SecurityContext       `json:"roksMetricsSecurityContextMaster"`
+	ROKSMetricsSecurityContextWorker          *SecurityContext       `json:"roksMetricsSecurityContextWorker"`
 	ExtraFeatureGates                         []string               `json:"extraFeatureGates"`
 	ControlPlaneOperatorSecurityContext       *SecurityContext       `json:"controlPlaneOperatorSecurityContext"`
 	MasterPriorityClass                       string                 `json:"masterPriorityClass"`

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -670,10 +670,10 @@ spec:
 {{ if .ROKSMetricsImage }}
         - name: metrics-pusher
           image: {{ .ROKSMetricsImage }}
-{{- if .ROKSMetricsSecurityContext }}
-{{- $securityContext := .ROKSMetricsSecurityContext }}
+{{- if .ROKSMetricsSecurityContextMaster }}
+{{- $securityContext := .ROKSMetricsSecurityContextMaster }}
           securityContext:
-            runAsNonRoot: {{ $securityContext.RunAsNonRoot }}
+            runAsUser: {{ $securityContext.RunAsUser }}
 {{- end }}
           imagePullPolicy: Always
           command:
@@ -1365,10 +1365,10 @@ spec:
 {{ end }}
 {{- if .ROKSMetricsImage }}
       - name: metrics-pusher
-{{- if .ROKSMetricsSecurityContext }}
-{{- $securityContext := .ROKSMetricsSecurityContext }}
+{{- if .ROKSMetricsSecurityContextMaster }}
+{{- $securityContext := .ROKSMetricsSecurityContextMaster }}
         securityContext:
-          runAsNonRoot: {{ $securityContext.RunAsNonRoot }}
+          runAsUser: {{ $securityContext.RunAsUser }}
 {{- end }}
         image: {{ .ROKSMetricsImage }}
         imagePullPolicy: Always
@@ -3510,8 +3510,8 @@ spec:
           effect: NoSchedule
       containers:
       - name: metrics
-{{- if .ROKSMetricsSecurityContext }}
-{{- $securityContext := .ROKSMetricsSecurityContext }}
+{{- if .ROKSMetricsSecurityContextWorker }}
+{{- $securityContext := .ROKSMetricsSecurityContextWorker }}
         securityContext:
           runAsNonRoot: {{ $securityContext.RunAsNonRoot }}
 {{- end }}
@@ -3586,8 +3586,8 @@ spec:
           effect: NoSchedule
       containers:
       - name: push-gateway
-{{- if .ROKSMetricsSecurityContext }}
-{{- $securityContext := .ROKSMetricsSecurityContext }}
+{{- if .ROKSMetricsSecurityContextWorker }}
+{{- $securityContext := .ROKSMetricsSecurityContextWorker }}
         securityContext:
           runAsNonRoot: {{ $securityContext.RunAsNonRoot }}
 {{- end }}


### PR DESCRIPTION
Kept failing with
```
          "waiting": {
            "message": "container has runAsNonRoot and image will run as root",
            "reason": "CreateContainerConfigError"
          }
```
Seems to be running fine when `runAsUser: 1000` is set