### PR TITLE
Support setting kube-apiserver log verbosity

### DIFF
--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -126,9 +126,12 @@ spec:
         - kube-apiserver
         args:
         - "--openshift-config=/etc/kubernetes/apiserver-config/config.yaml"
-{{ if .KPInfo }}
+{{- if .KPInfo }}
         - "--encryption-provider-config=/etc/kubernetes/kms-config/config.yaml"
-{{ end }}
+{{- end }}
+{{- if .KubeAPIServerVerbosity }}
+        - "--v={{ .KubeAPIServerVerbosity }}"
+{{- end }}
         workingDir: /var/log/kube-apiserver
 {{- if .ApiserverLivenessProbe }}
 {{- $probe := .ApiserverLivenessProbe }}

--- a/cluster.yaml.example
+++ b/cluster.yaml.example
@@ -226,3 +226,4 @@ oAuthServerSecurityContext:
   runAsUser: 1000
 clusterConfigOperatorSecurityContext:
   runAsUser: 1000
+kubeAPIServerVerbosity: 3

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -83,6 +83,7 @@ type ClusterParams struct {
 	SchedulerLivenessProbe                    *Probe `json:"schedulerLivenessProbe,omitempty"`
 	KMSLivenessProbe                          *Probe `json:"kmsLivenessProbe,omitempty"`
 	PortierisLivenessProbe                    *Probe `json:"portierisLivenessProbe,omitempty"`
+	KubeAPIServerVerbosity                    uint   `json:"kubeAPIServerVerbosity"`
 }
 
 type NamedCert struct {

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1407,9 +1407,12 @@ spec:
         - kube-apiserver
         args:
         - "--openshift-config=/etc/kubernetes/apiserver-config/config.yaml"
-{{ if .KPInfo }}
+{{- if .KPInfo }}
         - "--encryption-provider-config=/etc/kubernetes/kms-config/config.yaml"
-{{ end }}
+{{- end }}
+{{- if .KubeAPIServerVerbosity }}
+        - "--v={{ .KubeAPIServerVerbosity }}"
+{{- end }}
         workingDir: /var/log/kube-apiserver
 {{- if .ApiserverLivenessProbe }}
 {{- $probe := .ApiserverLivenessProbe }}


### PR DESCRIPTION
IBM Cloud likes to see HTTP requests in the kube-apiserver logs.
This adds optional kubeAPIServerVerbosity field to the cluster yaml.

Fixes: https://github.ibm.com/alchemy-containers/armada-update/issues/2039