### PR TITLE
[release-4.5] Support setting kube-apiserver log verbosity

### DIFF
--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -71,9 +71,12 @@ spec:
         - kube-apiserver
         args:
         - "--openshift-config=/etc/kubernetes/apiserver-config/config.yaml"
-{{ if .KPInfo }}
+{{- if .KPInfo }}
         - "--encryption-provider-config=/etc/kubernetes/kms-config/config.yaml"
-{{ end }}
+{{- end }}
+{{- if .KubeAPIServerVerbosity }}
+        - "--v={{ .KubeAPIServerVerbosity }}"
+{{- end }}
         workingDir: /var/log/kube-apiserver
 {{- if .ApiserverLivenessProbe }}
 {{- $probe := .ApiserverLivenessProbe }}

--- a/cluster.yaml.example
+++ b/cluster.yaml.example
@@ -215,3 +215,4 @@ clusterConfigOperatorSecurityContext:
   runAsUser: 1000
 portierisEnabled: false
 portierisImage: ''
+kubeAPIServerVerbosity: 3

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -78,6 +78,7 @@ type ClusterParams struct {
 	SchedulerLivenessProbe                    *Probe `json:"schedulerLivenessProbe",omitempty`
 	KMSLivenessProbe                          *Probe `json:"kmsLivenessProbe",omitempty`
 	PortierisLivenessProbe                    *Probe `json:"portierisLivenessProbe",omitempty`
+	KubeAPIServerVerbosity                    uint   `json:"kubeAPIServerVerbosity"`
 }
 
 type NamedCert struct {

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1213,9 +1213,12 @@ spec:
         - kube-apiserver
         args:
         - "--openshift-config=/etc/kubernetes/apiserver-config/config.yaml"
-{{ if .KPInfo }}
+{{- if .KPInfo }}
         - "--encryption-provider-config=/etc/kubernetes/kms-config/config.yaml"
-{{ end }}
+{{- end }}
+{{- if .KubeAPIServerVerbosity }}
+        - "--v={{ .KubeAPIServerVerbosity }}"
+{{- end }}
         workingDir: /var/log/kube-apiserver
 {{- if .ApiserverLivenessProbe }}
 {{- $probe := .ApiserverLivenessProbe }}


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/ibm-roks-toolkit/pull/159

IBM Cloud likes to see HTTP requests in the kube-apiserver logs.
This adds optional kubeAPIServerVerbosity field to the cluster yaml.

Fixes: https://github.ibm.com/alchemy-containers/armada-update/issues/2039