### PR TITLE
Add openshift-oauth-apiserver namespace to bootstrap namespaces

### DIFF
--- a/assets/cluster-bootstrap/00000_namespaces-needed-for-monitoring.yaml
+++ b/assets/cluster-bootstrap/00000_namespaces-needed-for-monitoring.yaml
@@ -43,3 +43,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-authentication
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-oauth-apiserver


### PR DESCRIPTION
Creates the namespace to prevent CVO error
`openshift-oauth-apiserver/prometheus-k8s" (468 of 546): resource may have been deleted`