### PR TITLE
[release 4.6] Add openshift-oauth-apiserver namespace to bootstrap namespaces

### DIFF
--- a/assets/cluster-bootstrap/00000_namespaces-needed-for-monitoring.yaml
+++ b/assets/cluster-bootstrap/00000_namespaces-needed-for-monitoring.yaml
@@ -43,3 +43,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-authentication
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-oauth-apiserver

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -164,6 +164,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-authentication
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-oauth-apiserver
 `)
 
 func clusterBootstrap00000_namespacesNeededForMonitoringYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Adds namespace to bootstrap to prevent cvo error:
`"openshift-oauth-apiserver/prometheus-k8s" (468 of 546): resource may have been deleted`