### PR TITLE
Updated roks 4.7 audit api version

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "vendor/*|go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-04-14T21:15:03Z",
+  "generated_at": "2021-04-30T18:50:01Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/assets/kube-apiserver/default-audit-policy.yaml
+++ b/assets/kube-apiserver/default-audit-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: audit.k8s.io/v1beta1
+apiVersion: audit.k8s.io/v1
 kind: Policy
 omitStages:
 - RequestReceived

--- a/assets/oauth-apiserver/audit-policy.yaml
+++ b/assets/oauth-apiserver/audit-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: audit.k8s.io/v1beta1
+apiVersion: audit.k8s.io/v1
 kind: Policy
 omitStages:
 - RequestReceived

--- a/assets/openshift-apiserver/config.yaml
+++ b/assets/openshift-apiserver/config.yaml
@@ -22,7 +22,7 @@ auditConfig:
   maximumFileSizeMegabytes: 100
   maximumRetainedFiles: 10
   policyConfiguration:
-    apiVersion: audit.k8s.io/v1beta1
+    apiVersion: audit.k8s.io/v1
     kind: Policy
     omitStages:
     - RequestReceived

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1261,7 +1261,7 @@ func kubeApiserverConfigYaml() (*asset, error) {
 	return a, nil
 }
 
-var _kubeApiserverDefaultAuditPolicyYaml = []byte(`apiVersion: audit.k8s.io/v1beta1
+var _kubeApiserverDefaultAuditPolicyYaml = []byte(`apiVersion: audit.k8s.io/v1
 kind: Policy
 omitStages:
 - RequestReceived
@@ -2490,7 +2490,7 @@ func kubeSchedulerKubeSchedulerSecretYaml() (*asset, error) {
 	return a, nil
 }
 
-var _oauthApiserverAuditPolicyYaml = []byte(`apiVersion: audit.k8s.io/v1beta1
+var _oauthApiserverAuditPolicyYaml = []byte(`apiVersion: audit.k8s.io/v1
 kind: Policy
 omitStages:
 - RequestReceived
@@ -3399,7 +3399,7 @@ auditConfig:
   maximumFileSizeMegabytes: 100
   maximumRetainedFiles: 10
   policyConfiguration:
-    apiVersion: audit.k8s.io/v1beta1
+    apiVersion: audit.k8s.io/v1
     kind: Policy
     omitStages:
     - RequestReceived


### PR DESCRIPTION
Changed the ROKS 4.7 audit api version from ```audit.k8s.io/v1beta1``` to the GA version ```audit.k8s.io/v1```

Related to this [issue](https://github.ibm.com/alchemy-containers/armada-update/issues/2100)