### PR TITLE
Fixing ingress-to-route-controller syntax error

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "vendor/*|go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-04-30T18:50:01Z",
+  "generated_at": "2021-05-04T14:18:04Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -115,7 +115,7 @@
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2917,
+        "line_number": 2918,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/assets/cluster-bootstrap/ingress-to-route-controller-clusterrolebinding.yaml
+++ b/assets/cluster-bootstrap/ingress-to-route-controller-clusterrolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
 roleRef:
   kind: ClusterRole
   name: system:openshift:openshift-controller-manager:ingress-to-route-controller
+  apiGroup: rbac.authorization.k8s.io 
 subjects:
 - kind: ServiceAccount
   namespace: openshift-infra

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -539,6 +539,7 @@ metadata:
 roleRef:
   kind: ClusterRole
   name: system:openshift:openshift-controller-manager:ingress-to-route-controller
+  apiGroup: rbac.authorization.k8s.io 
 subjects:
 - kind: ServiceAccount
   namespace: openshift-infra


### PR DESCRIPTION
Added ```apiGroup: rbac.authorization.k8s.io``` to roleRef to prevent kubectl from failing.

Related to this [issue](https://github.ibm.com/alchemy-containers/armada-update/issues/2085)