### PR TITLE
Fixing ingress-to-route-controller syntax error

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "vendor/*|go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-03-31T13:42:01Z",
+  "generated_at": "2021-05-07T16:25:33Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -115,7 +115,7 @@
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2174,
+        "line_number": 2282,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/assets/cluster-bootstrap/ingress-to-route-controller-clusterrolebinding.yaml
+++ b/assets/cluster-bootstrap/ingress-to-route-controller-clusterrolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
 roleRef:
   kind: ClusterRole
   name: system:openshift:openshift-controller-manager:ingress-to-route-controller
+  apiGroup: rbac.authorization.k8s.io 
 subjects:
 - kind: ServiceAccount
   namespace: openshift-infra

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -533,6 +533,7 @@ metadata:
 roleRef:
   kind: ClusterRole
   name: system:openshift:openshift-controller-manager:ingress-to-route-controller
+  apiGroup: rbac.authorization.k8s.io 
 subjects:
 - kind: ServiceAccount
   namespace: openshift-infra


### PR DESCRIPTION
This is a ROKS 4.6 cherry pick of this [PR](https://github.com/openshift/ibm-roks-toolkit/pull/198)