### PR TITLE
Specify platform type in Spec of Infrastructure resource

### DIFF
--- a/assets/cluster-bootstrap/cluster-infrastructure-02-config.yaml
+++ b/assets/cluster-bootstrap/cluster-infrastructure-02-config.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   cloudConfig:
     name: ""
+  platformSpec:
+    type: {{ .PlatformType }}
 status:
   apiServerInternalURI: https://{{ .ExternalAPIDNSName }}:{{ .ExternalAPIPort }}
   apiServerURL: https://{{ .ExternalAPIDNSName }}:{{ .ExternalAPIPort }}

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -259,6 +259,8 @@ metadata:
 spec:
   cloudConfig:
     name: ""
+  platformSpec:
+    type: {{ .PlatformType }}
 status:
   apiServerInternalURI: https://{{ .ExternalAPIDNSName }}:{{ .ExternalAPIPort }}
   apiServerURL: https://{{ .ExternalAPIDNSName }}:{{ .ExternalAPIPort }}


### PR DESCRIPTION
What this does: adds platform type to the Spec portion of the
Infrastructure resource that is synced to the guest cluster.

Why is it needed? The OpenShift console looks at Spec and not status to
determine platform type and decide whether an External storage cluster
is allowed. See https://bugzilla.redhat.com/show_bug.cgi?id=1952832