### PR TITLE
adding apiserver-network-proxy initial support

### DIFF
--- a/assets/konnectivity/konnectivity-server-deployment.yaml
+++ b/assets/konnectivity/konnectivity-server-deployment.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: konnectivity-server
+  labels:
+    app: konnectivity-server
+    clusterID: {{ .ClusterID }}
+spec:
+  selector:
+    matchLabels:
+      app: konnectivity-server
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 3
+      maxUnavailable: 1
+  revisionHistoryLimit: 10
+  template:
+    metadata:
+      labels:
+        app: konnectivity-server
+        clusterID: {{ .ClusterID }}
+{{- if .RestartDate }}
+      annotations:
+        openshift.io/restartedAt: "{{ .RestartDate }}"
+{{- end }}
+    spec:
+      containers:
+      - name: konnectivity-server
+{{- if .KonnectivityServerSecurityContext }}
+{{- $securityContext := .KonnectivityServerSecurityContext }}
+        securityContext:
+          runAsUser: {{ $securityContext.RunAsUser }}
+{{- end }}
+        image: {{ .KonnectivityServerImage }}
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/proxy-server"]
+        args: [
+                "--server-key=/etc/kubernetes/konn-certs/konnectivity-server-key.pem",
+                "--server-cert=/etc/kubernetes/konn-certs/konnectivity-server.pem",
+                "--server-ca-cert=/etc/kubernetes/konn-certs/ca.crt",
+                "--cluster-key=/etc/kubernetes/server.key",
+                "--cluster-cert=/etc/kubernetes/server.crt",
+                "--server-port={{ .KonnectivityServerPort }}",
+                "--agent-port={{ .KonnectivityAgentPort }}",
+                "--health-port={{ .KonnectivityServerHealthPort }}",
+                "--admin-port={{ .KonnectivityServerAdminPort }}",
+                "--mode=http-connect",
+                "--proxy-strategies=destHost,defaultRoute",
+                "--v=5"
+              ]
+{{- if .KonnectivityServerContainerResources }}
+        resources: {{ range .KonnectivityServerContainerResources }}{{ range .ResourceRequest }}
+          requests: {{ if .CPU }}
+            cpu: {{ .CPU }}{{ end }}{{ if .Memory }}
+            memory: {{ .Memory }}{{ end }}{{ end }}{{ range .ResourceLimit }}
+          limits: {{ if .CPU }}
+            cpu: {{ .CPU }}{{ end }}{{ if .Memory }}
+            memory: {{ .Memory }}{{ end }}{{ end }}{{ end }}
+{{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .KonnectivityServerHealthPort }}
+            scheme: HTTP
+          initialDelaySeconds: 300
+          periodSeconds: 120
+          successThreshold: 1
+          failureThreshold: 3
+          timeoutSeconds: 160
+        ports:
+        - name: server
+          containerPort: {{ .KonnectivityServerPort }}
+        - name: agent
+          containerPort: {{ .KonnectivityAgentPort }}
+        - name: health
+          containerPort: {{ .KonnectivityServerHealthPort }}
+        - name: admin
+          containerPort: {{ .KonnectivityServerAdminPort }}
+        volumeMounts:
+        - mountPath: /etc/kubernetes/konn-certs/
+          name: konnectivity-server-secret
+        - mountPath: /etc/kubernetes/
+          name: kube-apiserver-secret
+      tolerations:
+        - key: "multi-az-worker"
+          operator: "Equal"
+          value: "true"
+          effect: NoSchedule
+      volumes:
+      - name: kube-apiserver-secret
+        secret:
+          secretName: kube-apiserver
+      - name: konnectivity-server-secret
+        secret:
+          secretName: konnectivity-server-secret

--- a/assets/konnectivity/konnectivity-server-services.yaml
+++ b/assets/konnectivity/konnectivity-server-services.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: konnectivity-server-agent
+  labels:
+    app: konnectivity-server
+spec:
+  ports:
+    - name: konnectivity-agent
+      port: {{ .KonnectivityAgentPort }}
+      targetPort: {{ .KonnectivityAgentPort }}
+{{- if .KonnectivityServerAgentNodePort }}
+      nodePort: {{ .KonnectivityServerAgentNodePort }}
+{{- end }}
+      protocol: TCP
+  selector:
+    app: konnectivity-server
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: konnectivity-server
+  labels:
+    app: konnectivity-server
+spec:
+  ports:
+    - name: konnectivity-server
+      port: {{ .KonnectivityServerPort }}
+      targetPort: {{ .KonnectivityServerPort }}
+      protocol: TCP
+  selector:
+    app: konnectivity-server
+  type: ClusterIP

--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -129,6 +129,9 @@ spec:
 {{- if .KPInfo }}
         - "--encryption-provider-config=/etc/kubernetes/kms-config/config.yaml"
 {{- end }}
+{{- if .KonnectivityEnabled }}
+        - "--egress-selector-config-file=/etc/kubernetes/config/egress-config.yaml"
+{{- end }}
 {{- if .KubeAPIServerVerbosity }}
         - "--v={{ .KubeAPIServerVerbosity }}"
 {{- end }}

--- a/cluster.yaml.example
+++ b/cluster.yaml.example
@@ -153,6 +153,13 @@ portierisContainerResources:
     - resourceLimit:
         - cpu: 200m
           memory: 200Mi
+konnectivityServerContainerResources:
+    - resourceRequest:
+        - cpu: 100m
+          memory: 100Mi
+    - resourceLimit:
+        - cpu: 200m
+          memory: 200Mi
 kmsImage: example.image:v1.0.0
 kmsAPIKey: abcdefghijklmnopqrstuvwxyz
 kpInfo: '{"example":"foobar"}'
@@ -226,4 +233,13 @@ oAuthServerSecurityContext:
   runAsUser: 1000
 clusterConfigOperatorSecurityContext:
   runAsUser: 1000
+konnectivityServerSecurityContext:
+  runAsUser: 1000
 kubeAPIServerVerbosity: 3
+konnectivityEnabled: false
+konnectivityServerImage: ''
+konnectivityServerPort: 8090
+konnectivityAgentPort: 8091
+konnectivityServerHealthPort: 8092
+konnectivityServerAdminPort: 8095
+konnectivityServerAgentNodePort: 32321

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -75,15 +75,24 @@ type ClusterParams struct {
 	ClusterPolicyControllerSecurityContext    *SecurityContext       `json:"clusterPolicyControllerSecurityContext"`
 	ClusterConfigOperatorSecurityContext      *SecurityContext       `json:"clusterConfigOperatorSecurityContext"`
 	DefaultFeatureGates                       []string
-	PlatformType                              string `json:"platformType"`
-	EndpointPublishingStrategyScope           string `json:"endpointPublishingStrategyScope"`
-	ApiserverLivenessProbe                    *Probe `json:"apiserverLivenessProbe,omitempty"`
-	ApiserverReadinessProbe                   *Probe `json:"apiserverReadinessProbe,omitempty"`
-	ControllerManagerLivenessProbe            *Probe `json:"controllerManagerLivenessProbe,omitempty"`
-	SchedulerLivenessProbe                    *Probe `json:"schedulerLivenessProbe,omitempty"`
-	KMSLivenessProbe                          *Probe `json:"kmsLivenessProbe,omitempty"`
-	PortierisLivenessProbe                    *Probe `json:"portierisLivenessProbe,omitempty"`
-	KubeAPIServerVerbosity                    uint   `json:"kubeAPIServerVerbosity"`
+	PlatformType                              string                 `json:"platformType"`
+	EndpointPublishingStrategyScope           string                 `json:"endpointPublishingStrategyScope"`
+	ApiserverLivenessProbe                    *Probe                 `json:"apiserverLivenessProbe,omitempty"`
+	ApiserverReadinessProbe                   *Probe                 `json:"apiserverReadinessProbe,omitempty"`
+	ControllerManagerLivenessProbe            *Probe                 `json:"controllerManagerLivenessProbe,omitempty"`
+	SchedulerLivenessProbe                    *Probe                 `json:"schedulerLivenessProbe,omitempty"`
+	KMSLivenessProbe                          *Probe                 `json:"kmsLivenessProbe,omitempty"`
+	PortierisLivenessProbe                    *Probe                 `json:"portierisLivenessProbe,omitempty"`
+	KubeAPIServerVerbosity                    uint                   `json:"kubeAPIServerVerbosity"`
+	KonnectivityEnabled                       bool                   `json:"konnectivityEnabled"`
+	KonnectivityServerImage                   string                 `json:"konnectivityServerImage"`
+	KonnectivityServerSecurityContext         *SecurityContext       `json:"konnectivityServerSecurityContext"`
+	KonnectivityServerContainerResources      []ResourceRequirements `json:"konnectivityServerContainerResources"`
+	KonnectivityServerPort                    uint                   `json:"konnectivityServerPort"`
+	KonnectivityAgentPort                     uint                   `json:"konnectivityAgentPort"`
+	KonnectivityServerHealthPort              uint                   `json:"konnectivityServerHealthPort"`
+	KonnectivityServerAdminPort               uint                   `json:"konnectivityServerAdminPort"`
+	KonnectivityServerAgentNodePort           uint                   `json:"konnectivityServerAgentNodePort"`
 }
 
 type NamedCert struct {

--- a/pkg/cmd/render/manifests.go
+++ b/pkg/cmd/render/manifests.go
@@ -45,7 +45,7 @@ func (o *RenderManifestsOptions) Run() error {
 	if len(params.ExternalOauthDNSName) == 0 {
 		params.ExternalOauthDNSName = params.ExternalAPIDNSName
 	}
-	err = render.RenderClusterManifests(params, o.PullSecretFile, o.OutputDir, externalOauth, o.IncludeRegistry)
+	err = render.RenderClusterManifests(params, o.PullSecretFile, o.OutputDir, externalOauth, o.IncludeRegistry, params.KonnectivityEnabled)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
should be cherrypicked to 4.8

update: https://github.com/openshift/ibm-roks-toolkit/pull/219 was created with the requested changes due to permission issues