### PR TITLE
Update the metrics and push-gateway deployments to use system-cluster…

### DIFF
--- a/assets/roks-metrics/roks-metrics-deployment.yaml
+++ b/assets/roks-metrics/roks-metrics-deployment.yaml
@@ -51,6 +51,7 @@ spec:
             cpu: "10m"
             memory: "50Mi"
       serviceAccountName: roks-metrics 
+      priorityClassName: system-cluster-critical
       volumes:
       - name: serving-cert
         secret:

--- a/assets/roks-metrics/roks-metrics-push-gateway-deployment.yaml
+++ b/assets/roks-metrics/roks-metrics-push-gateway-deployment.yaml
@@ -27,6 +27,7 @@ spec:
           operator: "Equal"
           value: "true"
           effect: NoSchedule
+      priorityClassName: system-cluster-critical
       containers:
       - name: push-gateway
 {{- if .ROKSMetricsSecurityContextWorker }}

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -4805,6 +4805,7 @@ spec:
             cpu: "10m"
             memory: "50Mi"
       serviceAccountName: roks-metrics 
+      priorityClassName: system-cluster-critical
       volumes:
       - name: serving-cert
         secret:
@@ -4857,6 +4858,7 @@ spec:
           operator: "Equal"
           value: "true"
           effect: NoSchedule
+      priorityClassName: system-cluster-critical
       containers:
       - name: push-gateway
 {{- if .ROKSMetricsSecurityContextWorker }}


### PR DESCRIPTION
Update the metrics and push-gateway deployments in the openshift-roks-metrics namespace to use the system-cluster-critical priority class.