### PR TITLE
nodePort service for satellite ROKS

### DIFF
--- a/assets/cluster-bootstrap/cluster-ingresscontrollers-02-config.yaml
+++ b/assets/cluster-bootstrap/cluster-ingresscontrollers-02-config.yaml
@@ -4,11 +4,16 @@ metadata:
   name: default
   namespace: openshift-ingress-operator
 spec:
+{{ if or .EndpointPublishingStrategyScope .EndpointPublishingStrategyNode }}
+   endpointPublishingStrategy:
 {{ if .EndpointPublishingStrategyScope }}
-  endpointPublishingStrategy:
-    loadBalancer:
-      scope: {{ .EndpointPublishingStrategyScope }}
-    type: LoadBalancerService
+     loadBalancer:
+       scope: {{ .EndpointPublishingStrategyScope }}
+     type: LoadBalancerService
+{{ else }}
+    nodePort:
+      protocol: TCP
+    type: NodePortService
 {{ end }}
   nodePlacement:
     tolerations:

--- a/cluster.yaml.example
+++ b/cluster.yaml.example
@@ -17,7 +17,8 @@ releaseImage: quay.io/openshift-release-dev/ocp-release:4.2.0
 originReleasePrefix: quay.io/openshift-release-dev
 apiNodePort: 32323
 openVPNNodePort: 32324
-endpointPublishingStrategyScope: External
+endpointPublishingStrategyNodePort:
+    Protocol: TCP
 ingressSubdomain: apps.hosted.example.com
 openshiftAPIClusterIP: 172.30.0.20
 oauthAPIClusterIP: 172.30.0.21

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -316,11 +316,16 @@ metadata:
   name: default
   namespace: openshift-ingress-operator
 spec:
+{{ if or .EndpointPublishingStrategyScope .EndpointPublishingStrategyNode }}
+   endpointPublishingStrategy:
 {{ if .EndpointPublishingStrategyScope }}
-  endpointPublishingStrategy:
-    loadBalancer:
-      scope: {{ .EndpointPublishingStrategyScope }}
-    type: LoadBalancerService
+     loadBalancer:
+       scope: {{ .EndpointPublishingStrategyScope }}
+     type: LoadBalancerService
+{{ else }}
+    nodePort:
+      protocol: TCP
+    type: NodePortService
 {{ end }}
   nodePlacement:
     tolerations:


### PR DESCRIPTION
Add NodePort service type for ROKS on satellite. (Rel4.8 later)
issue: https://github.ibm.com/alchemy-containers/armada-frontdoor/issues/5190