### PR TITLE
Add dedicated master support for ROKS 4

### DIFF
--- a/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
+++ b/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
@@ -30,6 +30,10 @@ spec:
                       values: ["{{ .ClusterID }}"]
                 topologyKey: "kubernetes.io/hostname"
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"

--- a/assets/control-plane-operator/cp-operator-deployment.yaml
+++ b/assets/control-plane-operator/cp-operator-deployment.yaml
@@ -74,6 +74,10 @@ spec:
                       values: ["{{ .ClusterID }}"]
                 topologyKey: "kubernetes.io/hostname"
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"

--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -25,6 +25,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"

--- a/assets/kube-controller-manager/kube-controller-manager-deployment.yaml
+++ b/assets/kube-controller-manager/kube-controller-manager-deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"

--- a/assets/kube-scheduler/kube-scheduler-deployment.yaml
+++ b/assets/kube-scheduler/kube-scheduler-deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"

--- a/assets/oauth-apiserver/oauth-apiserver-deployment.yaml
+++ b/assets/oauth-apiserver/oauth-apiserver-deployment.yaml
@@ -25,6 +25,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"

--- a/assets/oauth-openshift/oauth-server-deployment.yaml
+++ b/assets/oauth-openshift/oauth-server-deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "master-{{ .ClusterID }}"
+        effect: NoSchedule
       - key: "multi-az-worker"
         operator: "Equal"
         value: "true"

--- a/assets/openshift-apiserver/openshift-apiserver-deployment.yaml
+++ b/assets/openshift-apiserver/openshift-apiserver-deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"

--- a/assets/openshift-controller-manager/cluster-policy-controller-deployment.yaml
+++ b/assets/openshift-controller-manager/cluster-policy-controller-deployment.yaml
@@ -27,6 +27,10 @@ spec:
           operator: "Equal"
           value: "true"
           effect: NoSchedule
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
       affinity:
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/assets/openshift-controller-manager/openshift-controller-manager-deployment.yaml
+++ b/assets/openshift-controller-manager/openshift-controller-manager-deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"

--- a/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
+++ b/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
@@ -22,6 +22,10 @@ metadata:
   name: manifests-bootstrapper
 spec:
   tolerations:
+    - key: "dedicated"
+      operator: "Equal"
+      value: "master-{{ .ClusterID }}"
+      effect: NoSchedule
     - key: "multi-az-worker"
       operator: "Equal"
       value: "true"

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1530,6 +1530,10 @@ spec:
                       values: ["{{ .ClusterID }}"]
                 topologyKey: "kubernetes.io/hostname"
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"
@@ -1792,6 +1796,10 @@ spec:
                       values: ["{{ .ClusterID }}"]
                 topologyKey: "kubernetes.io/hostname"
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"
@@ -2254,6 +2262,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"
@@ -2954,6 +2966,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"
@@ -3202,6 +3218,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"
@@ -3459,6 +3479,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"
@@ -3970,6 +3994,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "master-{{ .ClusterID }}"
+        effect: NoSchedule
       - key: "multi-az-worker"
         operator: "Equal"
         value: "true"
@@ -4396,6 +4424,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"
@@ -4691,6 +4723,10 @@ spec:
           operator: "Equal"
           value: "true"
           effect: NoSchedule
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
       affinity:
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -4895,6 +4931,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"
@@ -5547,6 +5587,10 @@ metadata:
   name: manifests-bootstrapper
 spec:
   tolerations:
+    - key: "dedicated"
+      operator: "Equal"
+      value: "master-{{ .ClusterID }}"
+      effect: NoSchedule
     - key: "multi-az-worker"
       operator: "Equal"
       value: "true"


### PR DESCRIPTION
Added dedicated master support for ROKS 4 on following components
 

- [x] cluster-version-operator-deployment
- [x] cp-operator-deployment
- [x] kube-apiserver-deployment
- [x] kube-controller-manager-deployment
- [x] kube-scheduler-deployment
- [x] oauth-apiserver-deployment
- [x] oauth-server-deployment
- [x] openshift-apiserver-deployment
- [x] cluster-policy-controller-deployment
- [x] openshift-controller-manager-deployment
- [x] manifest bootstrapper pod