### PR TITLE
Add dedicated master support for ROKS 4[release-4.6]

### DIFF
--- a/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
+++ b/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
@@ -30,6 +30,10 @@ spec:
                       values: ["{{ .ClusterID }}"]
                 topologyKey: "kubernetes.io/hostname"
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"

--- a/assets/control-plane-operator/cp-operator-deployment.yaml
+++ b/assets/control-plane-operator/cp-operator-deployment.yaml
@@ -74,6 +74,10 @@ spec:
                       values: ["{{ .ClusterID }}"]
                 topologyKey: "kubernetes.io/hostname"
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"

--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -25,6 +25,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"

--- a/assets/kube-controller-manager/kube-controller-manager-deployment.yaml
+++ b/assets/kube-controller-manager/kube-controller-manager-deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"

--- a/assets/kube-scheduler/kube-scheduler-deployment.yaml
+++ b/assets/kube-scheduler/kube-scheduler-deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"

--- a/assets/oauth-openshift/oauth-server-deployment.yaml
+++ b/assets/oauth-openshift/oauth-server-deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "master-{{ .ClusterID }}"
+        effect: NoSchedule
       - key: "multi-az-worker"
         operator: "Equal"
         value: "true"

--- a/assets/openshift-apiserver/openshift-apiserver-deployment.yaml
+++ b/assets/openshift-apiserver/openshift-apiserver-deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"

--- a/assets/openshift-controller-manager/cluster-policy-controller-deployment.yaml
+++ b/assets/openshift-controller-manager/cluster-policy-controller-deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"

--- a/assets/openshift-controller-manager/openshift-controller-manager-deployment.yaml
+++ b/assets/openshift-controller-manager/openshift-controller-manager-deployment.yaml
@@ -23,6 +23,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"

--- a/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
+++ b/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
@@ -22,6 +22,10 @@ metadata:
   name: manifests-bootstrapper
 spec:
   tolerations:
+    - key: "dedicated"
+      operator: "Equal"
+      value: "master-{{ .ClusterID }}"
+      effect: NoSchedule
     - key: "multi-az-worker"
       operator: "Equal"
       value: "true"

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -725,6 +725,10 @@ spec:
                       values: ["{{ .ClusterID }}"]
                 topologyKey: "kubernetes.io/hostname"
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"
@@ -946,6 +950,10 @@ spec:
                       values: ["{{ .ClusterID }}"]
                 topologyKey: "kubernetes.io/hostname"
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"
@@ -1278,6 +1286,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"
@@ -1917,6 +1929,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"
@@ -2130,6 +2146,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"
@@ -2484,6 +2504,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "master-{{ .ClusterID }}"
+        effect: NoSchedule
       - key: "multi-az-worker"
         operator: "Equal"
         value: "true"
@@ -2907,6 +2931,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"
@@ -3198,6 +3226,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"
@@ -3406,6 +3438,10 @@ spec:
 {{ end }}
     spec:
       tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "master-{{ .ClusterID }}"
+          effect: NoSchedule
         - key: "multi-az-worker"
           operator: "Equal"
           value: "true"
@@ -4056,6 +4092,10 @@ metadata:
   name: manifests-bootstrapper
 spec:
   tolerations:
+    - key: "dedicated"
+      operator: "Equal"
+      value: "master-{{ .ClusterID }}"
+      effect: NoSchedule
     - key: "multi-az-worker"
       operator: "Equal"
       value: "true"


### PR DESCRIPTION
This the cherrypick for [release-4.6](for the https://github.com/openshift/ibm-roks-toolkit/pull/251#issuecomment-916406936).

The old cherrypick is failed because of we don't have `auth-apiserver` deployments in 4.6