### PR TITLE
change the user-manifest-openshift-browser-client cm to secret

### DIFF
--- a/assets/oauth-openshift/oauth-browser-client.yaml
+++ b/assets/oauth-openshift/oauth-browser-client.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: user-manifest-openshift-browser-client
-data:
+type: Opaque
+stringData:
   data: |
     apiVersion: oauth.openshift.io/v1
     grantMethod: auto

--- a/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
+++ b/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
@@ -76,6 +76,7 @@ spec:
           for name in $(oc get cm | grep '^user-manifest-' | awk '{ print $1 }'); do
              oc get cm ${name} -o jsonpath='{ .data.data }' > "${name}.yaml"
           done
+          oc get secret user-manifest-openshift-browser-client -ojsonpath='{ .data.data }' | base64 -d > "user-manifest-openshift-browser-client.yaml"
           export KUBECONFIG=/etc/openshift/kubeconfig
           oc apply -f $(pwd)
           # Replace the global certs configmap here because it's too large to oc apply

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3774,10 +3774,11 @@ func oauthApiserverServiceTemplateYaml() (*asset, error) {
 }
 
 var _oauthOpenshiftOauthBrowserClientYaml = []byte(`apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: user-manifest-openshift-browser-client
-data:
+type: Opaque
+stringData:
   data: |
     apiVersion: oauth.openshift.io/v1
     grantMethod: auto
@@ -5641,6 +5642,7 @@ spec:
           for name in $(oc get cm | grep '^user-manifest-' | awk '{ print $1 }'); do
              oc get cm ${name} -o jsonpath='{ .data.data }' > "${name}.yaml"
           done
+          oc get secret user-manifest-openshift-browser-client -ojsonpath='{ .data.data }' | base64 -d > "user-manifest-openshift-browser-client.yaml"
           export KUBECONFIG=/etc/openshift/kubeconfig
           oc apply -f $(pwd)
           # Replace the global certs configmap here because it's too large to oc apply


### PR DESCRIPTION
As per [convo](https://github.com/openshift/ibm-roks-toolkit/issues/151 ) change the  user-manifest-openshift-browser-client cm to secret.

I need to validated this on any one of the test cluster before merge into Master. 