### PR TITLE
Remove the deprecated kubelet-https flag from Api-server

### DIFF
--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -132,8 +132,6 @@ apiServerArguments:
   - /etc/kubernetes/secret/kubelet-client.crt
   kubelet-client-key:
   - /etc/kubernetes/secret/kubelet-client.key
-  kubelet-https:
-  - 'true'
   kubelet-preferred-address-types:
   - InternalIP
   kubelet-read-only-port:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2007,8 +2007,6 @@ apiServerArguments:
   - /etc/kubernetes/secret/kubelet-client.crt
   kubelet-client-key:
   - /etc/kubernetes/secret/kubelet-client.key
-  kubelet-https:
-  - 'true'
   kubelet-preferred-address-types:
   - InternalIP
   kubelet-read-only-port:


### PR DESCRIPTION
Remove the deprecated kubelet-https flag from Api-server

Description: 
Api server PODs are failing in 4.9 clusters(Kubernetes v1.22) due to the deprecated kubelet flag. 
For more info: https://github.com/kubernetes/kubernetes/pull/101178
