### PR TITLE
Omit 3CMO manifests from CVO

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "vendor/*|go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-10-21T18:18:05Z",
+  "generated_at": "2021-11-04T12:34:13Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -126,7 +126,7 @@
         "hashed_secret": "733c83df12b5f09020cfc0ad9411ba17e7d1a093",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2985,
+        "line_number": 3026,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -134,7 +134,7 @@
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3730,
+        "line_number": 3771,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
+++ b/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
@@ -42,6 +42,41 @@ spec:
 {{ if .MasterPriorityClass }}
       priorityClassName: {{ .MasterPriorityClass }}
 {{ end }}
+      initContainers:
+        - name: prepare-payload
+          image: {{ .ReleaseImage }}
+          imagePullPolicy: Always
+{{- if .ClusterVersionOperatorSecurityContext }}
+{{- $securityContext := .ClusterVersionOperatorSecurityContext }}
+          securityContext:
+            runAsUser: {{ $securityContext.RunAsUser }}
+{{- end }}
+          command:
+            - /bin/bash
+          args:
+            - -c
+            - -|
+              cp -R /manifests /var/payload/
+              cp -R /release-manifests /var/payload/
+
+              # TODO(jonesbr): This InitContainer can be removed once the annotiation is removed from these files
+              # These PRs and their cherry-picks to be merged
+              # - https://github.com/openshift/cluster-authentication-operator/pull/496
+              # - https://github.com/openshift/cloud-credential-operator/pull/398
+              rm /var/payload/release-manifests/0000_50_cloud-credential-operator_01-operator-config.yaml
+              rm /var/payload/release-manifests/0000_50_cluster-authentication-operator_02_config.cr.yaml
+{{ if .ClusterVersionOperatorResources }}
+          resources:{{ range .ClusterVersionOperatorResources }}{{ range .ResourceRequest }}
+            requests: {{ if .CPU }}
+              cpu: {{ .CPU }}{{ end }}{{ if .Memory }}
+              memory: {{ .Memory }}{{ end }}{{ end }}{{ range .ResourceLimit }}
+            limits: {{ if .CPU }}
+              cpu: {{ .CPU }}{{ end }}{{ if .Memory }}
+              memory: {{ .Memory }}{{ end }}{{ end }}{{ end }}
+{{ end }}
+          volumeMounts:
+            - mountPath: /var/payload
+              name: payload
       containers:
         - name: cluster-version-operator
           image: {{ .ReleaseImage }}
@@ -83,13 +118,17 @@ spec:
             - mountPath: /etc/tls/serving-cert
               name: serving-cert
               readOnly: true
+            - mountPath: /var/payload
+              name: payload
           env:
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: EXCLUDE_MANIFESTS
-              value: internal-openshift-hosted
+            - name: CLUSTER_PROFILE
+              value: ibm-cloud-managed
+            - name: PAYLOAD_OVERRIDE
+              value: /var/payload
 {{ if .ROKSMetricsImage }}
         - name: metrics-pusher
           image: {{ .ROKSMetricsImage }}
@@ -132,3 +171,5 @@ spec:
         - name: config
           configMap:
             name: cluster-version-operator
+        - name: payload
+          emptyDir: {}


### PR DESCRIPTION
Setting up an init container to remove the manifests for the 3CMO from
the cluster-version-operator. This will stop the 3CMO from being deployed
to the cluster, as it is not needed.