### PR TITLE
Fix syntax of CVO init container

### DIFF
--- a/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
+++ b/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - /bin/bash
           args:
             - -c
-            - -|
+            - |-
               cp -R /manifests /var/payload/
               cp -R /release-manifests /var/payload/
 

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1555,7 +1555,7 @@ spec:
             - /bin/bash
           args:
             - -c
-            - -|
+            - |-
               cp -R /manifests /var/payload/
               cp -R /release-manifests /var/payload/
 


### PR DESCRIPTION
Fix to match syntax used in [hypershift](https://github.com/openshift/hypershift/pull/265/files#diff-db006d6909a497e5d7bd7fb7371731bf2442a1ba9533d30f84842f71089e168eR28)