### PR TITLE
CVO initContainer syntax to work with ansible

### DIFF
--- a/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
+++ b/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
@@ -54,15 +54,15 @@ spec:
           command:
             - /bin/bash
           args:
-            - -c
+            - "-c"
             - |-
               cp -R /manifests /var/payload/
               cp -R /release-manifests /var/payload/
 
               # TODO(jonesbr): This InitContainer can be removed once the annotiation is removed from these files
               # These PRs and their cherry-picks to be merged
-              # - https://github.com/openshift/cluster-authentication-operator/pull/496
-              # - https://github.com/openshift/cloud-credential-operator/pull/398
+              # https://github.com/openshift/cluster-authentication-operator/pull/496
+              # https://github.com/openshift/cloud-credential-operator/pull/398
               rm /var/payload/release-manifests/0000_50_cloud-credential-operator_01-operator-config.yaml
               rm /var/payload/release-manifests/0000_50_cluster-authentication-operator_02_config.cr.yaml
 {{ if .ClusterVersionOperatorResources }}

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1554,15 +1554,15 @@ spec:
           command:
             - /bin/bash
           args:
-            - -c
+            - "-c"
             - |-
               cp -R /manifests /var/payload/
               cp -R /release-manifests /var/payload/
 
               # TODO(jonesbr): This InitContainer can be removed once the annotiation is removed from these files
               # These PRs and their cherry-picks to be merged
-              # - https://github.com/openshift/cluster-authentication-operator/pull/496
-              # - https://github.com/openshift/cloud-credential-operator/pull/398
+              # https://github.com/openshift/cluster-authentication-operator/pull/496
+              # https://github.com/openshift/cloud-credential-operator/pull/398
               rm /var/payload/release-manifests/0000_50_cloud-credential-operator_01-operator-config.yaml
               rm /var/payload/release-manifests/0000_50_cluster-authentication-operator_02_config.cr.yaml
 {{ if .ClusterVersionOperatorResources }}


### PR DESCRIPTION
While the syntax used in the container works when editing a deployment,
ansible doesn't like parsing it. Fixing up the syntax to make ansible happy.

Verified that this actually works with a test cluster
```
test2          c660q0a003njarnqhfp0   normal   21 minutes ago   3         test       4.9.5_1241_openshift   Default               classic   
```