### PR TITLE
Add nodeAffinity for Master Components

### DIFF
--- a/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
+++ b/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
@@ -19,6 +19,15 @@ spec:
 {{ end }}
     spec:
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/assets/control-plane-operator/cp-operator-deployment.yaml
+++ b/assets/control-plane-operator/cp-operator-deployment.yaml
@@ -63,6 +63,15 @@ spec:
 {{ end }}
     spec:
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -34,6 +34,15 @@ spec:
           value: "true"
           effect: NoSchedule
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/assets/kube-controller-manager/kube-controller-manager-deployment.yaml
+++ b/assets/kube-controller-manager/kube-controller-manager-deployment.yaml
@@ -32,6 +32,15 @@ spec:
           value: "true"
           effect: NoSchedule
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/assets/kube-scheduler/kube-scheduler-deployment.yaml
+++ b/assets/kube-scheduler/kube-scheduler-deployment.yaml
@@ -32,6 +32,15 @@ spec:
           value: "true"
           effect: NoSchedule
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/assets/oauth-apiserver/oauth-apiserver-deployment.yaml
+++ b/assets/oauth-apiserver/oauth-apiserver-deployment.yaml
@@ -34,6 +34,15 @@ spec:
           value: "true"
           effect: NoSchedule
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/assets/oauth-openshift/oauth-server-deployment.yaml
+++ b/assets/oauth-openshift/oauth-server-deployment.yaml
@@ -32,6 +32,15 @@ spec:
         value: "true"
         effect: NoSchedule
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/assets/openshift-apiserver/openshift-apiserver-deployment.yaml
+++ b/assets/openshift-apiserver/openshift-apiserver-deployment.yaml
@@ -32,6 +32,15 @@ spec:
           value: "true"
           effect: NoSchedule
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/assets/openshift-controller-manager/cluster-policy-controller-deployment.yaml
+++ b/assets/openshift-controller-manager/cluster-policy-controller-deployment.yaml
@@ -32,6 +32,15 @@ spec:
           value: "master-{{ .ClusterID }}"
           effect: NoSchedule
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/assets/openshift-controller-manager/openshift-controller-manager-deployment.yaml
+++ b/assets/openshift-controller-manager/openshift-controller-manager-deployment.yaml
@@ -32,6 +32,15 @@ spec:
           value: "true"
           effect: NoSchedule
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
+++ b/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
@@ -21,6 +21,16 @@ kind: Pod
 metadata:
   name: manifests-bootstrapper
 spec:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+          - key: dedicated
+            operator: In
+            values:
+            - master-{{ .ClusterID }}
   tolerations:
     - key: "dedicated"
       operator: "Equal"

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1519,6 +1519,15 @@ spec:
 {{ end }}
     spec:
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -1826,6 +1835,15 @@ spec:
 {{ end }}
     spec:
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -2310,6 +2328,15 @@ spec:
           value: "true"
           effect: NoSchedule
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -2954,6 +2981,15 @@ spec:
           value: "true"
           effect: NoSchedule
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -3208,6 +3244,15 @@ spec:
           value: "true"
           effect: NoSchedule
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -3469,6 +3514,15 @@ spec:
           value: "true"
           effect: NoSchedule
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -3985,6 +4039,15 @@ spec:
         value: "true"
         effect: NoSchedule
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -4415,6 +4478,15 @@ spec:
           value: "true"
           effect: NoSchedule
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -4710,6 +4782,15 @@ spec:
           value: "master-{{ .ClusterID }}"
           effect: NoSchedule
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -4926,6 +5007,15 @@ spec:
           value: "true"
           effect: NoSchedule
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: dedicated
+                operator: In
+                values:
+                - master-{{ .ClusterID }}
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -5572,6 +5662,16 @@ kind: Pod
 metadata:
   name: manifests-bootstrapper
 spec:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+          - key: dedicated
+            operator: In
+            values:
+            - master-{{ .ClusterID }}
   tolerations:
     - key: "dedicated"
       operator: "Equal"


### PR DESCRIPTION
Updated to support master pods to dedicated nodes for ROKS 4.9 on following components
 
- [x] cluster-version-operator-deployment
- [x] cp-operator-deployment
- [x] kube-apiserver-deployment
- [x] kube-controller-manager-deployment
- [x] kube-scheduler-deployment
- [x] oauth-apiserver-deployment
- [x] oauth-server-deployment
- [x] openshift-apiserver-deployment
- [x] cluster-policy-controller-deployment
- [x] openshift-controller-manager-deployment
- [x] manifest bootstrapper pod

Need to cherry pick to 4.9 Once code is merged.