### PR TITLE
Fixes for 4.6.48+

### DIFF
--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -62,7 +62,62 @@ spec:
 {{ if .MasterPriorityClass }}
       priorityClassName: {{ .MasterPriorityClass }}
 {{ end }}
+      initContainers:
+      - image: {{ imageFor "cluster-config-operator" }}
+{{- if .ClusterConfigOperatorSecurityContext }}
+{{- $securityContext := .ClusterConfigOperatorSecurityContext }}
+        securityContext:
+          runAsUser: {{ $securityContext.RunAsUser }}
+{{- end }}
+        imagePullPolicy: IfNotPresent
+        name: config-bootstrap
+        workingDir: /tmp
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - |-
+          cd /tmp
+          mkdir input output
+          /usr/bin/cluster-config-operator render --config-output-file config --asset-input-dir /tmp/input --asset-output-dir /tmp/output
+          cp /tmp/output/manifests/* /work
+        volumeMounts:
+        - mountPath: /work
+          name: bootstrap-manifests
       containers:
+      - image: {{ imageFor "cli" }}
+{{- if .ManifestBootstrapperSecurityContext }}
+{{- $securityContext := .ManifestBootstrapperSecurityContext }}
+        securityContext:
+          runAsUser: {{ $securityContext.RunAsUser }}
+{{- end }}
+        name: initialize-manifests
+        env:
+        - name: KUBECONFIG
+          value: /var/secrets/localhost-kubeconfig/kubeconfig
+        workingDir: /work
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - |-
+          while true; do
+            if oc apply -f .; then
+              echo "Bootstrap manifests applied successfully."
+              break
+            fi
+            sleep 1
+          done
+          while true; do
+            sleep 1000
+          done
+        volumeMounts:
+        - mountPath: /work
+          name: bootstrap-manifests
+          readOnly: true
+        - mountPath: /var/secrets/localhost-kubeconfig
+          name: localhost-kubeconfig
+          readOnly: true
       - name: kube-apiserver
 {{- if .KubeAPIServerSecurityContext }}
 {{- $securityContext := .KubeAPIServerSecurityContext }}
@@ -323,6 +378,8 @@ spec:
           readOnly: true
 {{ end }}
       volumes:
+      - name: bootstrap-manifests
+        emptyDir: {}
       - secret:
           secretName: kube-apiserver
           defaultMode: 0640
@@ -338,6 +395,9 @@ spec:
       - configMap:
           name: kube-apiserver-oauth-metadata
         name: oauth
+      - secret:
+          secretName: localhost-admin-kubeconfig
+        name: localhost-kubeconfig
 {{- if or .ROKSMetricsImage .PortierisEnabled }}
       - secret:
           secretName: service-network-admin-kubeconfig

--- a/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
+++ b/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
@@ -56,27 +56,6 @@ spec:
       volumeMounts:
         - mountPath: /work
           name: work
-    - image: {{ imageFor "cluster-config-operator" }}
-{{- if .ClusterConfigOperatorSecurityContext }}
-{{- $securityContext := .ClusterConfigOperatorSecurityContext }}
-      securityContext:
-        runAsUser: {{ $securityContext.RunAsUser }}
-{{- end }}
-      imagePullPolicy: IfNotPresent
-      name: config-operator
-      workingDir: /tmp
-      command:
-        - /bin/bash
-      args:
-        - -c
-        - |-
-          cd /tmp
-          mkdir input output
-          /usr/bin/cluster-config-operator render --config-output-file config --asset-input-dir /tmp/input --asset-output-dir /tmp/output
-          cp /tmp/output/manifests/* /work
-      volumeMounts:
-        - mountPath: /work
-          name: work
   containers:
     - image: {{ imageFor "cli" }}
       imagePullPolicy: IfNotPresent


### PR DESCRIPTION
In 4.6.48 a kube apiserver backport requires that the kube apiserver
config be initialized concurrently with the kube apiserver. This change
(which was made for 4.7) needs to be backported to 4.6 to allow the API
server to not crash.

Tested with 4.6.48 and 4.6.51

This change requires a change on the ansible side to add a `localhost-admin-kubeconfig` secret with a kubeconfig that talks to localhost in the same way that 4.7+ requires (https://github.com/openshift/ibm-roks-toolkit/pull/144)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2026146