### PR TITLE
update kms timeout to 4 hours

### DIFF
--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -270,7 +270,7 @@ spec:
         - name: NUM_LEN_BYTES
           value: "4"
         - name: CACHE_TIMEOUT_IN_HOURS
-          value: "1"
+          value: "4"
         - name: RESTART_DELAY_IN_SECONDS
           value: "0"
         - name: UNIX_SOCKET_PATH

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2779,7 +2779,7 @@ spec:
         - name: NUM_LEN_BYTES
           value: "4"
         - name: CACHE_TIMEOUT_IN_HOURS
-          value: "1"
+          value: "4"
         - name: RESTART_DELAY_IN_SECONDS
           value: "0"
         - name: UNIX_SOCKET_PATH


### PR DESCRIPTION
To provide more stability around KMS provider outages and network disruptions, keys can now be cached for up to 4 hours.