### PR TITLE
ROKS v4.9: Disable Kubernetes API server profiling

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "vendor/*|go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-01-13T18:25:18Z",
+  "generated_at": "2022-01-24T21:38:06Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -138,7 +138,7 @@
         "hashed_secret": "733c83df12b5f09020cfc0ad9411ba17e7d1a093",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3087,
+        "line_number": 3089,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -146,7 +146,7 @@
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3750,
+        "line_number": 3752,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -126,6 +126,8 @@ apiServerArguments:
   - '2000'
   insecure-port:
   - '0'
+  profiling:
+  - 'false'
   kubelet-certificate-authority:
   - /etc/kubernetes/config/kubelet-client-ca.crt
   kubelet-client-certificate:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2167,6 +2167,8 @@ apiServerArguments:
   - '2000'
   insecure-port:
   - '0'
+  profiling:
+  - 'false'
   kubelet-certificate-authority:
   - /etc/kubernetes/config/kubelet-client-ca.crt
   kubelet-client-certificate:


### PR DESCRIPTION
Related to this issue to disable the kube-apiserver-profiling for ROKS 4.9: https://github.ibm.com/alchemy-containers/armada-update/issues/2771