### PR TITLE
Bump detect-secrets version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   # You are encouraged to use static refs such as tags, instead of branch name
   #
   # Running "pre-commit autoupdate" would automatically updates rev to latest tag
-  rev: 0.13.1+ibm.46.dss
+  rev: 0.13.1+ibm.47.dss
   hooks:
   - id: detect-secrets # pragma: whitelist secret
     # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "vendor/*|go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-01-24T21:38:06Z",
+  "generated_at": "2022-02-08T18:19:52Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -172,7 +172,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.46.dss",
+  "version": "0.13.1+ibm.47.dss",
   "word_list": {
     "file": null,
     "hash": null


### PR DESCRIPTION
Doing this to respin images for CVE remediation. Newly spun images will be
built on the 4.11 base due to https://github.com/openshift/release/pull/26103