### PR TITLE
Remove yum invocation from Dockerfiles

### DIFF
--- a/Dockerfile.cpoperator
+++ b/Dockerfile.cpoperator
@@ -7,6 +7,5 @@ RUN go build -mod=vendor -o ./bin/control-plane-operator ./cmd/control-plane-ope
 
 # Base image on release is pulled from https://github.com/openshift/release/blob/master/ci-operator/config/openshift/ibm-roks-toolkit/openshift-ibm-roks-toolkit-release-4.*.yaml
 FROM quay.io/openshift/origin-base:latest
-RUN yum -y update && yum clean all
 COPY --from=builder /go/src/github.com/openshift/ibm-roks-toolkit/bin/control-plane-operator /usr/bin/control-plane-operator
 ENTRYPOINT /usr/bin/control-plane-operator

--- a/Dockerfile.metrics
+++ b/Dockerfile.metrics
@@ -12,7 +12,6 @@ RUN cd /tmp && \
 
 # Base image on release is pulled from https://github.com/openshift/release/blob/master/ci-operator/config/openshift/ibm-roks-toolkit/openshift-ibm-roks-toolkit-release-4.9.yaml
 FROM quay.io/openshift/origin-base:latest
-RUN yum -y update && yum clean all
 COPY --from=builder /go/src/github.com/openshift/ibm-roks-toolkit/bin/roks-metrics /usr/bin/roks-metrics
 COPY --from=builder /go/src/github.com/openshift/ibm-roks-toolkit/bin/metrics-pusher /usr/bin/metrics-pusher
 COPY --from=builder /pushgateway /usr/bin/pushgateway


### PR DESCRIPTION
In order to switch to using a ubi base image, we need to avoid calling yum in Dockerfiles because it's not present.