### PR TITLE
Remove minReadySeconds from cluster policy controller

### DIFF
--- a/assets/openshift-controller-manager/cluster-policy-controller-deployment.yaml
+++ b/assets/openshift-controller-manager/cluster-policy-controller-deployment.yaml
@@ -12,7 +12,6 @@ spec:
   selector:
     matchLabels:
       app: cluster-policy-controller
-  minReadySeconds: 30
   template:
     metadata:
       labels:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -4692,7 +4692,6 @@ spec:
   selector:
     matchLabels:
       app: cluster-policy-controller
-  minReadySeconds: 30
   template:
     metadata:
       labels:


### PR DESCRIPTION
The cluster policy controller has a habit of crashing during rollouts
which can confuse the Kubernetes controller manager when minReadySeconds
is set. While we believe the root cause of the problem is a Kubernetes
controller manager bug (likely fixed in the latest releases), we are
going to remove minReadySeconds until we can confirm that the problem
is fully resolved.