### PR TITLE
Use kubescheduler.config.k8s.io/v1beta2 API

### DIFF
--- a/assets/kube-scheduler/config.yaml
+++ b/assets/kube-scheduler/config.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubescheduler.config.k8s.io/v1beta1
+apiVersion: kubescheduler.config.k8s.io/v1beta2
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: "/etc/kubernetes/secret/kubeconfig"

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3235,7 +3235,7 @@ func kubeControllerManagerKubeControllerManagerDeploymentYaml() (*asset, error) 
 	return a, nil
 }
 
-var _kubeSchedulerConfigYaml = []byte(`apiVersion: kubescheduler.config.k8s.io/v1beta1
+var _kubeSchedulerConfigYaml = []byte(`apiVersion: kubescheduler.config.k8s.io/v1beta2
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: "/etc/kubernetes/secret/kubeconfig"


### PR DESCRIPTION
Kubernetes scheduler configuration must now use the v1beta2 API
for OpenShift version 4.10.