### PR TITLE
Remove CVO init container

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "vendor/*|go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-02-17T15:24:26Z",
+  "generated_at": "2022-02-28T21:01:30Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -138,7 +138,7 @@
         "hashed_secret": "733c83df12b5f09020cfc0ad9411ba17e7d1a093",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3163,
+        "line_number": 3122,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -146,7 +146,7 @@
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3826,
+        "line_number": 3785,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
+++ b/assets/cluster-version-operator/cluster-version-operator-deployment.yaml
@@ -51,41 +51,6 @@ spec:
 {{ if .MasterPriorityClass }}
       priorityClassName: {{ .MasterPriorityClass }}
 {{ end }}
-      initContainers:
-        - name: prepare-payload
-          image: {{ .ReleaseImage }}
-          imagePullPolicy: Always
-{{- if .ClusterVersionOperatorSecurityContext }}
-{{- $securityContext := .ClusterVersionOperatorSecurityContext }}
-          securityContext:
-            runAsUser: {{ $securityContext.RunAsUser }}
-{{- end }}
-          command:
-            - /bin/bash
-          args:
-            - "-c"
-            - |-
-              cp -R /manifests /var/payload/
-              cp -R /release-manifests /var/payload/
-
-              # TODO(jonesbr): This InitContainer can be removed once the annotiation is removed from these files
-              # These PRs and their cherry-picks to be merged
-              # https://github.com/openshift/cluster-authentication-operator/pull/496
-              # https://github.com/openshift/cloud-credential-operator/pull/398
-              rm /var/payload/release-manifests/0000_50_cloud-credential-operator_01-operator-config.yaml
-              rm /var/payload/release-manifests/0000_50_cluster-authentication-operator_02_config.cr.yaml
-{{ if .ClusterVersionOperatorResources }}
-          resources:{{ range .ClusterVersionOperatorResources }}{{ range .ResourceRequest }}
-            requests: {{ if .CPU }}
-              cpu: {{ .CPU }}{{ end }}{{ if .Memory }}
-              memory: {{ .Memory }}{{ end }}{{ end }}{{ range .ResourceLimit }}
-            limits: {{ if .CPU }}
-              cpu: {{ .CPU }}{{ end }}{{ if .Memory }}
-              memory: {{ .Memory }}{{ end }}{{ end }}{{ end }}
-{{ end }}
-          volumeMounts:
-            - mountPath: /var/payload
-              name: payload
       containers:
         - name: cluster-version-operator
           image: {{ .ReleaseImage }}
@@ -127,8 +92,6 @@ spec:
             - mountPath: /etc/tls/serving-cert
               name: serving-cert
               readOnly: true
-            - mountPath: /var/payload
-              name: payload
           env:
             - name: NODE_NAME
               valueFrom:
@@ -136,8 +99,6 @@ spec:
                   fieldPath: spec.nodeName
             - name: CLUSTER_PROFILE
               value: ibm-cloud-managed
-            - name: PAYLOAD_OVERRIDE
-              value: /var/payload
 {{ if .ROKSMetricsImage }}
         - name: metrics-pusher
           image: {{ .ROKSMetricsImage }}
@@ -184,5 +145,3 @@ spec:
         - name: config
           configMap:
             name: cluster-version-operator
-        - name: payload
-          emptyDir: {}

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1792,41 +1792,6 @@ spec:
 {{ if .MasterPriorityClass }}
       priorityClassName: {{ .MasterPriorityClass }}
 {{ end }}
-      initContainers:
-        - name: prepare-payload
-          image: {{ .ReleaseImage }}
-          imagePullPolicy: Always
-{{- if .ClusterVersionOperatorSecurityContext }}
-{{- $securityContext := .ClusterVersionOperatorSecurityContext }}
-          securityContext:
-            runAsUser: {{ $securityContext.RunAsUser }}
-{{- end }}
-          command:
-            - /bin/bash
-          args:
-            - "-c"
-            - |-
-              cp -R /manifests /var/payload/
-              cp -R /release-manifests /var/payload/
-
-              # TODO(jonesbr): This InitContainer can be removed once the annotiation is removed from these files
-              # These PRs and their cherry-picks to be merged
-              # https://github.com/openshift/cluster-authentication-operator/pull/496
-              # https://github.com/openshift/cloud-credential-operator/pull/398
-              rm /var/payload/release-manifests/0000_50_cloud-credential-operator_01-operator-config.yaml
-              rm /var/payload/release-manifests/0000_50_cluster-authentication-operator_02_config.cr.yaml
-{{ if .ClusterVersionOperatorResources }}
-          resources:{{ range .ClusterVersionOperatorResources }}{{ range .ResourceRequest }}
-            requests: {{ if .CPU }}
-              cpu: {{ .CPU }}{{ end }}{{ if .Memory }}
-              memory: {{ .Memory }}{{ end }}{{ end }}{{ range .ResourceLimit }}
-            limits: {{ if .CPU }}
-              cpu: {{ .CPU }}{{ end }}{{ if .Memory }}
-              memory: {{ .Memory }}{{ end }}{{ end }}{{ end }}
-{{ end }}
-          volumeMounts:
-            - mountPath: /var/payload
-              name: payload
       containers:
         - name: cluster-version-operator
           image: {{ .ReleaseImage }}
@@ -1868,8 +1833,6 @@ spec:
             - mountPath: /etc/tls/serving-cert
               name: serving-cert
               readOnly: true
-            - mountPath: /var/payload
-              name: payload
           env:
             - name: NODE_NAME
               valueFrom:
@@ -1877,8 +1840,6 @@ spec:
                   fieldPath: spec.nodeName
             - name: CLUSTER_PROFILE
               value: ibm-cloud-managed
-            - name: PAYLOAD_OVERRIDE
-              value: /var/payload
 {{ if .ROKSMetricsImage }}
         - name: metrics-pusher
           image: {{ .ROKSMetricsImage }}
@@ -1925,8 +1886,6 @@ spec:
         - name: config
           configMap:
             name: cluster-version-operator
-        - name: payload
-          emptyDir: {}
 `)
 
 func clusterVersionOperatorClusterVersionOperatorDeploymentYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Removing the init container and payload logic added in https://github.com/openshift/ibm-roks-toolkit/pull/284.
The PRs referenced in the init container's comment have been merged.