### PR TITLE
[release-4.9] Fix config observer updates

### DIFF
--- a/pkg/controllers/openshiftapiserver/controller.go
+++ b/pkg/controllers/openshiftapiserver/controller.go
@@ -210,23 +210,34 @@ func mergeConfig(existingYAML, updateJSON []byte) (updatedYAML []byte, err error
 	if err = json.NewDecoder(bytes.NewBuffer(updateJSON)).Decode(&updateConfig); err != nil {
 		return
 	}
-	for key := range updateConfig {
-		switch key {
-		case "projectConfig":
-			existingConfig[key] = updateConfig[key]
-		case "imagePolicyConfig":
-			resultValue := existingConfig[key].(map[string]interface{})
-			if mapValue, ok := updateConfig[key].(map[string]interface{}); ok {
-				for key2 := range mapValue {
-					switch key2 {
-					case "internalRegistryHostname", "allowedRegistriesForImport":
-						resultValue[key2] = mapValue[key2]
-					}
+
+	if value, exists := updateConfig["projectConfig"]; exists {
+		existingConfig["projectConfig"] = value
+	} else {
+		delete(existingConfig, "projectConfig")
+	}
+
+	if value, exists := updateConfig["imagePolicyConfig"]; exists {
+		var resultValue map[string]interface{}
+		if existingValue, ok := existingConfig["imagePolicyConfig"]; !ok {
+			resultValue = map[string]interface{}{}
+		} else {
+			resultValue = existingValue.(map[string]interface{})
+		}
+		if mapValue, ok := value.(map[string]interface{}); ok {
+			for _, key := range []string{"internalRegistryHostname", "allowedRegistriesForImport"} {
+				if value, exists := mapValue[key]; exists {
+					resultValue[key] = value
+				} else {
+					delete(resultValue, key)
 				}
 			}
-			existingConfig[key] = resultValue
 		}
+		existingConfig["imagePolicyConfig"] = resultValue
+	} else {
+		delete(existingConfig, "imagePolicyConfig")
 	}
+
 	var mergedConfig []byte
 	mergedConfig, err = json.Marshal(existingConfig)
 	if err != nil {

--- a/pkg/controllers/openshiftcontrollermanager/operator_client.go
+++ b/pkg/controllers/openshiftcontrollermanager/operator_client.go
@@ -145,10 +145,11 @@ func mergeConfig(existingYAML, updateJSON []byte) (updatedYAML []byte, err error
 	if err = json.NewDecoder(bytes.NewBuffer(updateJSON)).Decode(&updateConfig); err != nil {
 		return
 	}
-	for key := range updateConfig {
-		switch key {
-		case "dockerPullSecret", "build", "deployer":
-			existingConfig[key] = updateConfig[key]
+	for _, key := range []string{"dockerPullSecret", "build", "deployer"} {
+		if value, hasKey := updateConfig[key]; hasKey {
+			existingConfig[key] = value
+		} else {
+			delete(existingConfig, key)
 		}
 	}
 	var mergedConfig []byte


### PR DESCRIPTION
Fixes a bug in the merge functions for both openshift apiserver and
openshift controller manager configuration. The merge was not doing a
delete of existing keys if the key was not present in the update,
causing continuous updates.

Backport of #406 minus unit tests