### PR TITLE
DNM: Add Host_IP to kube-apiserver deployment to fix apirequestcount errors in ROKS 4.8

### DIFF
--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -206,6 +206,12 @@ spec:
             cpu: {{ .CPU }}{{ end }}{{ if .Memory }}
             memory: {{ .Memory }}{{ end }}{{ end }}{{ end }}
 {{ end }}
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
         volumeMounts:
         - mountPath: /etc/kubernetes/secret/
           name: secret

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2607,6 +2607,12 @@ spec:
             cpu: {{ .CPU }}{{ end }}{{ if .Memory }}
             memory: {{ .Memory }}{{ end }}{{ end }}{{ end }}
 {{ end }}
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
         volumeMounts:
         - mountPath: /etc/kubernetes/secret/
           name: secret


### PR DESCRIPTION
Related to this issue: https://github.ibm.com/alchemy-containers/armada-update/issues/2902 to fix the ROKS 4.8 to 4.9 
 upgrade instruction errors

**DNM until test results have been shared below**