### PR TITLE
[release-4.7] Remove minReadySeconds from deployments

### DIFF
--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -14,7 +14,6 @@ spec:
   selector:
     matchLabels:
       app: kube-apiserver
-  minReadySeconds: 15
   template:
     metadata:
       labels:

--- a/assets/kube-controller-manager/kube-controller-manager-deployment.yaml
+++ b/assets/kube-controller-manager/kube-controller-manager-deployment.yaml
@@ -12,7 +12,6 @@ spec:
   selector:
     matchLabels:
       app: kube-controller-manager
-  minReadySeconds: 30
   template:
     metadata:
       labels:

--- a/assets/kube-scheduler/kube-scheduler-deployment.yaml
+++ b/assets/kube-scheduler/kube-scheduler-deployment.yaml
@@ -12,7 +12,6 @@ spec:
   selector:
     matchLabels:
       app: kube-scheduler
-  minReadySeconds: 30
   template:
     metadata:
       labels:

--- a/assets/oauth-apiserver/oauth-apiserver-deployment.yaml
+++ b/assets/oauth-apiserver/oauth-apiserver-deployment.yaml
@@ -13,7 +13,6 @@ spec:
     matchLabels:
       app: openshift-oauth-apiserver
   progressDeadlineSeconds: 600
-  minReadySeconds: 15
   template:
     metadata:
       name: openshift-oauth-apiserver

--- a/assets/oauth-openshift/oauth-server-deployment.yaml
+++ b/assets/oauth-openshift/oauth-server-deployment.yaml
@@ -12,7 +12,6 @@ spec:
   selector:
     matchLabels:
       app: oauth-openshift
-  minReadySeconds: 30
   template:
     metadata:
       labels:

--- a/assets/openshift-apiserver/openshift-apiserver-deployment.yaml
+++ b/assets/openshift-apiserver/openshift-apiserver-deployment.yaml
@@ -12,7 +12,6 @@ spec:
   selector:
     matchLabels:
       app: openshift-apiserver
-  minReadySeconds: 30
   template:
     metadata:
       labels:

--- a/assets/openshift-controller-manager/openshift-controller-manager-deployment.yaml
+++ b/assets/openshift-controller-manager/openshift-controller-manager-deployment.yaml
@@ -12,7 +12,6 @@ spec:
   selector:
     matchLabels:
       app: openshift-controller-manager
-  minReadySeconds: 30
   template:
     metadata:
       labels:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1415,7 +1415,6 @@ spec:
   selector:
     matchLabels:
       app: kube-apiserver
-  minReadySeconds: 15
   template:
     metadata:
       labels:
@@ -2121,7 +2120,6 @@ spec:
   selector:
     matchLabels:
       app: kube-controller-manager
-  minReadySeconds: 30
   template:
     metadata:
       labels:
@@ -2371,7 +2369,6 @@ spec:
   selector:
     matchLabels:
       app: kube-scheduler
-  minReadySeconds: 30
   template:
     metadata:
       labels:
@@ -2632,7 +2629,6 @@ spec:
     matchLabels:
       app: openshift-oauth-apiserver
   progressDeadlineSeconds: 600
-  minReadySeconds: 15
   template:
     metadata:
       name: openshift-oauth-apiserver
@@ -3150,7 +3146,6 @@ spec:
   selector:
     matchLabels:
       app: oauth-openshift
-  minReadySeconds: 30
   template:
     metadata:
       labels:
@@ -3581,7 +3576,6 @@ spec:
   selector:
     matchLabels:
       app: openshift-apiserver
-  minReadySeconds: 30
   template:
     metadata:
       labels:
@@ -4090,7 +4084,6 @@ spec:
   selector:
     matchLabels:
       app: openshift-controller-manager
-  minReadySeconds: 30
   template:
     metadata:
       labels:


### PR DESCRIPTION
Remove minReadySeconds from deployments until [1] is fixed.

[1] https://github.com/kubernetes/kubernetes/issues/108266

This is a manual cherry-pick of https://github.com/openshift/ibm-roks-toolkit/pull/420.