### PR TITLE
Wait for image stream tag to reflect current commit before creating a release

### DIFF
--- a/hack/create-release.sh
+++ b/hack/create-release.sh
@@ -3,5 +3,6 @@ set -euo pipefail
 
 REPODIR="$(dirname "$0")/.."
 
+${REPODIR}/hack/wait-for-images.sh
 ${REPODIR}/hack/create-git-release.sh
 ${REPODIR}/hack/tag-release-images.sh

--- a/hack/wait-for-images.sh
+++ b/hack/wait-for-images.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+REPODIR="$(dirname "$0")/.."
+
+if [[ ! -f "${REPODIR}/release" ]]; then
+  echo "Release name file (release) does not exist. Nothing to do"
+fi
+if [[ ! -f "${REPODIR}/release-date" ]]; then
+  echo "Release date file (release-date) does not exist. Nothing to do"
+fi
+RELEASE="$(cat "${REPODIR}/release")"
+RELEASE_TAG="v${RELEASE}-$(cat "${REPODIR}/release-date")"
+RELEASE_BRANCH="release-${RELEASE}"
+
+if ! which oc &> /dev/null; then
+  echo "ERROR: the oc command is required for this script."
+  exit 1
+fi
+
+if ! git rev-parse --verify "${RELEASE_BRANCH}" &> /dev/null; then
+  echo "Skipping image release for master branch"
+  exit
+fi
+
+CURRENT_COMMIT="$(git rev-parse "${RELEASE_BRANCH}")"
+
+# Wait up to 45 minutes, otherwise exit
+timeout=45
+
+while [ $timeout -gt 0 ]; do
+  image_commit="$(oc get istag ibm-roks-${RELEASE}:metrics -n hypershift-toolkit -o jsonpath='{ .image.dockerImageMetadata.Config.Labels.io\.openshift\.build\.commit\.id }')"
+  if [[ $image_commit == $CURRENT_COMMIT ]]; then
+    echo "Tag with expected commit found ${image_commit}"
+    break
+  fi
+  echo "${timeout}: Waiting for image commit ${CURRENT_COMMIT}. Current image commit: ${image_commit}"
+  sleep 60
+  timeout=$(( $timeout - 1 ))
+done
+
+if [ $timeout -eq 0 ]; then
+  echo "Timed out waiting for commit"
+  exit 1
+fi
+
+


### PR DESCRIPTION
Adds a script that waits for an imagestream tag built from the current git commit. If after ~ 45 min an image is not found, the job will fail. To retry it, another commit (with an arbitrary change) will need to be merged.