### PR TITLE
Disable PodSecurity admission plugin for 4.10

### DIFF
--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -17,6 +17,17 @@ admission:
         restrictedCIDRs:
         - {{ .PodCIDR }}
         - {{ .ServiceCIDR }}
+    PodSecurity:
+      configuration:
+        kind: PodSecurityConfiguration
+        apiVersion: pod-security.admission.config.k8s.io/v1alpha1
+        defaults:
+          enforce: "privileged"
+          enforce-version: "latest"
+          audit: "baseline"
+          audit-version: "latest"
+          warn: "baseline"
+          warn-version: "latest"
 apiServerArguments:
   advertise-address:
   - "{{ .ExternalAPIIPAddress }}"
@@ -55,6 +66,8 @@ apiServerArguments:
   - /etc/kubernetes/config/serving-ca.crt
   cloud-provider:
   - "{{ .CloudProvider }}"
+  disable-admission-plugins:
+  - PodSecurity
   enable-admission-plugins:
   - CertificateApproval
   - CertificateSigning

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2140,6 +2140,17 @@ admission:
         restrictedCIDRs:
         - {{ .PodCIDR }}
         - {{ .ServiceCIDR }}
+    PodSecurity:
+      configuration:
+        kind: PodSecurityConfiguration
+        apiVersion: pod-security.admission.config.k8s.io/v1alpha1
+        defaults:
+          enforce: "privileged"
+          enforce-version: "latest"
+          audit: "baseline"
+          audit-version: "latest"
+          warn: "baseline"
+          warn-version: "latest"
 apiServerArguments:
   advertise-address:
   - "{{ .ExternalAPIIPAddress }}"
@@ -2178,6 +2189,8 @@ apiServerArguments:
   - /etc/kubernetes/config/serving-ca.crt
   cloud-provider:
   - "{{ .CloudProvider }}"
+  disable-admission-plugins:
+  - PodSecurity
   enable-admission-plugins:
   - CertificateApproval
   - CertificateSigning


### PR DESCRIPTION
OCP 4.10 disabled the PodSecurity admission plugin. 4.10 also has the
PodSecurity admission pluginConfig, so we might as well grab that even
though it has no affect with the plugin disabled.
See https://github.com/openshift/cluster-kube-apiserver-operator/blob/release-4.10/bindata/assets/config/defaultconfig.yaml

Partially implements https://github.ibm.com/alchemy-containers/armada-update/issues/3032