### PR TITLE
Disable PodSecurity in v4.10

### DIFF
--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -55,6 +55,8 @@ apiServerArguments:
   - /etc/kubernetes/config/serving-ca.crt
   cloud-provider:
   - "{{ .CloudProvider }}"
+  disable-admission-plugins:
+  - PodSecurity
   enable-admission-plugins:
   - CertificateApproval
   - CertificateSigning

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2178,6 +2178,8 @@ apiServerArguments:
   - /etc/kubernetes/config/serving-ca.crt
   cloud-provider:
   - "{{ .CloudProvider }}"
+  disable-admission-plugins:
+  - PodSecurity
   enable-admission-plugins:
   - CertificateApproval
   - CertificateSigning


### PR DESCRIPTION
Disable the PodSecury admission plugin for 4.10 to match OCP.

Partially implements https://github.ibm.com/alchemy-containers/armada-update/issues/3032