### PR TITLE
Enable PodSecurity in 4.11

### DIFF
--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -17,6 +17,17 @@ admission:
         restrictedCIDRs:
         - {{ .PodCIDR }}
         - {{ .ServiceCIDR }}
+    PodSecurity:
+      configuration:
+        kind: PodSecurityConfiguration
+        apiVersion: pod-security.admission.config.k8s.io/v1beta1
+        defaults:
+          enforce: "privileged"
+          enforce-version: "latest"
+          audit: "restricted"
+          audit-version: "latest"
+          warn: "restricted"
+          warn-version: "latest"
 apiServerArguments:
   advertise-address:
   - "{{ .ExternalAPIIPAddress }}"
@@ -70,6 +81,7 @@ apiServerArguments:
   - PersistentVolumeClaimResize
   - PersistentVolumeLabel
   - PodNodeSelector
+  - PodSecurity
   - PodTolerationRestriction
   - Priority
   - ResourceQuota

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2140,6 +2140,17 @@ admission:
         restrictedCIDRs:
         - {{ .PodCIDR }}
         - {{ .ServiceCIDR }}
+    PodSecurity:
+      configuration:
+        kind: PodSecurityConfiguration
+        apiVersion: pod-security.admission.config.k8s.io/v1beta1
+        defaults:
+          enforce: "privileged"
+          enforce-version: "latest"
+          audit: "restricted"
+          audit-version: "latest"
+          warn: "restricted"
+          warn-version: "latest"
 apiServerArguments:
   advertise-address:
   - "{{ .ExternalAPIIPAddress }}"
@@ -2193,6 +2204,7 @@ apiServerArguments:
   - PersistentVolumeClaimResize
   - PersistentVolumeLabel
   - PodNodeSelector
+  - PodSecurity
   - PodTolerationRestriction
   - Priority
   - ResourceQuota


### PR DESCRIPTION
PodSecurity is currently enabled in OCP 4.11. This updates our
kube-apiserver configuration with the same pluginConfig and
enabled-admission-plugin list.

Partially implements https://github.ibm.com/alchemy-containers/armada-update/issues/3032