### PR TITLE
update maxSurge and minReadySeconds

### DIFF
--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -9,11 +9,12 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
       app: kube-apiserver
+  minReadySeconds: 15
   template:
     metadata:
       labels:

--- a/assets/kube-controller-manager/kube-controller-manager-deployment.yaml
+++ b/assets/kube-controller-manager/kube-controller-manager-deployment.yaml
@@ -7,11 +7,12 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
       app: kube-controller-manager
+  minReadySeconds: 30
   template:
     metadata:
       labels:

--- a/assets/kube-scheduler/kube-scheduler-deployment.yaml
+++ b/assets/kube-scheduler/kube-scheduler-deployment.yaml
@@ -7,11 +7,12 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
       app: kube-scheduler
+  minReadySeconds: 30
   template:
     metadata:
       labels:

--- a/assets/oauth-apiserver/oauth-apiserver-deployment.yaml
+++ b/assets/oauth-apiserver/oauth-apiserver-deployment.yaml
@@ -7,12 +7,13 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
       app: openshift-oauth-apiserver
   progressDeadlineSeconds: 600
+  minReadySeconds: 15
   template:
     metadata:
       name: openshift-oauth-apiserver

--- a/assets/oauth-openshift/oauth-server-deployment.yaml
+++ b/assets/oauth-openshift/oauth-server-deployment.yaml
@@ -7,11 +7,12 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
       app: oauth-openshift
+  minReadySeconds: 15
   template:
     metadata:
       labels:

--- a/assets/openshift-apiserver/openshift-apiserver-deployment.yaml
+++ b/assets/openshift-apiserver/openshift-apiserver-deployment.yaml
@@ -7,11 +7,12 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
       app: openshift-apiserver
+  minReadySeconds: 15
   template:
     metadata:
       labels:

--- a/assets/openshift-controller-manager/cluster-policy-controller-deployment.yaml
+++ b/assets/openshift-controller-manager/cluster-policy-controller-deployment.yaml
@@ -7,7 +7,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:

--- a/assets/openshift-controller-manager/openshift-controller-manager-deployment.yaml
+++ b/assets/openshift-controller-manager/openshift-controller-manager-deployment.yaml
@@ -7,11 +7,12 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
       app: openshift-controller-manager
+  minReadySeconds: 30
   template:
     metadata:
       labels:

--- a/assets/roks-metrics/roks-metrics-deployment.yaml
+++ b/assets/roks-metrics/roks-metrics-deployment.yaml
@@ -8,7 +8,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 2
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
@@ -47,10 +47,10 @@ spec:
         - name: serving-cert
           mountPath: /var/run/secrets/serving-cert
         resources:
-          requests: 
+          requests:
             cpu: "10m"
             memory: "50Mi"
-      serviceAccountName: roks-metrics 
+      serviceAccountName: roks-metrics
       priorityClassName: system-cluster-critical
       volumes:
       - name: serving-cert

--- a/assets/roks-metrics/roks-metrics-push-gateway-deployment.yaml
+++ b/assets/roks-metrics/roks-metrics-push-gateway-deployment.yaml
@@ -8,7 +8,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 2
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
@@ -43,6 +43,6 @@ spec:
         - containerPort: 9091
           name: http
         resources:
-          requests: 
+          requests:
             cpu: "10m"
             memory: "50Mi"

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2478,11 +2478,12 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
       app: kube-apiserver
+  minReadySeconds: 15
   template:
     metadata:
       labels:
@@ -3091,11 +3092,12 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
       app: kube-controller-manager
+  minReadySeconds: 30
   template:
     metadata:
       labels:
@@ -3327,11 +3329,12 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
       app: kube-scheduler
+  minReadySeconds: 30
   template:
     metadata:
       labels:
@@ -3545,12 +3548,13 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
       app: openshift-oauth-apiserver
   progressDeadlineSeconds: 600
+  minReadySeconds: 15
   template:
     metadata:
       name: openshift-oauth-apiserver
@@ -4022,11 +4026,12 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
       app: oauth-openshift
+  minReadySeconds: 15
   template:
     metadata:
       labels:
@@ -4418,11 +4423,12 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
       app: openshift-apiserver
+  minReadySeconds: 15
   template:
     metadata:
       labels:
@@ -4716,7 +4722,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
@@ -4917,11 +4923,12 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 3
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
       app: openshift-controller-manager
+  minReadySeconds: 30
   template:
     metadata:
       labels:
@@ -5140,7 +5147,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 2
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
@@ -5179,10 +5186,10 @@ spec:
         - name: serving-cert
           mountPath: /var/run/secrets/serving-cert
         resources:
-          requests: 
+          requests:
             cpu: "10m"
             memory: "50Mi"
-      serviceAccountName: roks-metrics 
+      serviceAccountName: roks-metrics
       priorityClassName: system-cluster-critical
       volumes:
       - name: serving-cert
@@ -5217,7 +5224,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 2
+      maxSurge: 0
       maxUnavailable: 1
   selector:
     matchLabels:
@@ -5252,7 +5259,7 @@ spec:
         - containerPort: 9091
           name: http
         resources:
-          requests: 
+          requests:
             cpu: "10m"
             memory: "50Mi"
 `)


### PR DESCRIPTION
When the kube-apiserver deployment's priority class was increased all
the kube-server pods were deleted at the same time leading to a 2 - 3
minute kube-apiserver outage. It was determined this was due to
maxSurge: 3 giving us 3 new pods and the scheduler preempting (deleting)
the old pods becausae the new pods had a higher priority. Setting
maxSurge: 0 fixes (or at least works around) that problem. We also
found that maxSurge: 0 fixed the problem with minReadySeconds breaking
rollouts.

- Set maxSurge: 0 for deployments with multiple replicas
- Restore the minReadySeconds setting previously deleted

Fixes https://github.ibm.com/alchemy-containers/armada-update/issues/3237
Fixes https://github.ibm.com/alchemy-containers/armada-update/issues/3011