### PR TITLE
Restore minReadySeconds for cluster-policy-controller

### DIFF
--- a/assets/openshift-controller-manager/cluster-policy-controller-deployment.yaml
+++ b/assets/openshift-controller-manager/cluster-policy-controller-deployment.yaml
@@ -12,6 +12,7 @@ spec:
   selector:
     matchLabels:
       app: cluster-policy-controller
+  minReadySeconds: 30
   template:
     metadata:
       labels:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -4727,6 +4727,7 @@ spec:
   selector:
     matchLabels:
       app: cluster-policy-controller
+  minReadySeconds: 30
   template:
     metadata:
       labels:


### PR DESCRIPTION
minReadySeconds was removed in https://github.com/openshift/ibm-roks-toolkit/pull/391

It is safe to restore that now that we are using maxSurge: 0

Partially implements https://github.ibm.com/alchemy-containers/armada-update/issues/3011