### PR TITLE
Enable most gosec checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SRC_DIRS = cmd pkg
-GOSEC_VERSION := v2.11.0
+GOSEC_VERSION := v2.12.0
 
 .PHONY: default
 default: build
@@ -29,7 +29,7 @@ verify-gofmt:
 verify-gosec:
 	@echo Verifying gosec
 	@curl -sfL https://raw.githubusercontent.com/securego/gosec/${GOSEC_VERSION}/install.sh | sh -s -- -b /tmp ${GOSEC_VERSION}
-	@/tmp/gosec -concurrency 1 -exclude G104,G401,G402,G501 ./...
+	@/tmp/gosec -concurrency 1 -exclude G104 ./...
 
 .PHONY: verify
 verify: verify-gofmt verify-gosec verify-bindata

--- a/pkg/controllers/cmca/configmap_observer.go
+++ b/pkg/controllers/cmca/configmap_observer.go
@@ -3,7 +3,7 @@ package cmca
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
+	"crypto/md5" //#nosec - not used for security purposes
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -126,5 +126,5 @@ func (r *ManagedCAObserver) getAdditionalCAs(ctx context.Context, logger logr.Lo
 }
 
 func calculateHash(b []byte) string {
-	return fmt.Sprintf("%x", md5.Sum(b))
+	return fmt.Sprintf("%x", md5.Sum(b)) //#nosec - not used for security purposes
 }

--- a/pkg/controllers/openshiftapiserver/controller.go
+++ b/pkg/controllers/openshiftapiserver/controller.go
@@ -3,7 +3,7 @@ package openshiftapiserver
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
+	"crypto/md5" //#nosec - not used for security purposes
 	"encoding/json"
 	"fmt"
 	"time"
@@ -293,5 +293,5 @@ func (*noopResourceSyncer) SyncSecret(destination, source resourcesynccontroller
 }
 
 func calculateHash(b []byte) string {
-	return fmt.Sprintf("%x", md5.Sum(b))
+	return fmt.Sprintf("%x", md5.Sum(b)) //#nosec - not used for security purposes
 }

--- a/pkg/controllers/openshiftcontrollermanager/operator_client.go
+++ b/pkg/controllers/openshiftcontrollermanager/operator_client.go
@@ -3,7 +3,7 @@ package openshiftcontrollermanager
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
+	"crypto/md5" //#nosec - not used for security purposes
 	"encoding/json"
 	"fmt"
 	"time"
@@ -186,5 +186,5 @@ func (c *cmOperatorClient) UpdateOperatorStatus(ctx context.Context, oldResource
 }
 
 func calculateHash(b []byte) string {
-	return fmt.Sprintf("%x", md5.Sum(b))
+	return fmt.Sprintf("%x", md5.Sum(b)) //#nosec - not used for security purposes
 }

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -65,8 +65,9 @@ func (s *Server) Run() error {
 	smux := http.NewServeMux()
 	smux.Handle("/metrics", legacyregistry.HandlerWithReset())
 	server := &http.Server{
-		Addr:    s.ListenAddress,
-		Handler: smux,
+		Addr:              s.ListenAddress,
+		Handler:           smux,
+		ReadHeaderTimeout: 5 * time.Minute,
 	}
 	go func() {
 		klog.Infof("Listening on %s", s.ListenAddress)

--- a/pkg/metricspusher/pusher.go
+++ b/pkg/metricspusher/pusher.go
@@ -75,9 +75,14 @@ func (p *MetricsPusher) pushMetrics() {
 			caCertPool := x509.NewCertPool()
 			caCertPool.AppendCertsFromPEM(caCert)
 
+			tlsConfig := tls.Config{
+				RootCAs:    caCertPool,
+				MinVersion: tls.VersionTLS12,
+			}
+
 			tr := knet.SetTransportDefaults(&http.Transport{
 				TLSHandshakeTimeout: 10 * time.Second,
-				TLSClientConfig:     &tls.Config{RootCAs: caCertPool},
+				TLSClientConfig:     &tlsConfig,
 			})
 
 			client := &http.Client{Transport: tr}


### PR DESCRIPTION
Bumping to gosec v2.12.0, and removing most of the check exclusions
that we had in place before.

Also verifying that the verify-gosec check behaves properly in the CI.