### PR TITLE
Add openshift.io/user-monitoring label to ns

### DIFF
--- a/assets/cluster-bootstrap/00000_namespaces-needed-for-monitoring.yaml
+++ b/assets/cluster-bootstrap/00000_namespaces-needed-for-monitoring.yaml
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    openshift.io/user-monitoring: "false"
   name: openshift-apiserver
 ---
 apiVersion: v1
@@ -24,6 +26,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    openshift.io/user-monitoring: "false"
   name: openshift-kube-controller-manager
 ---
 apiVersion: v1
@@ -42,4 +46,6 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    openshift.io/user-monitoring: "false"
   name: openshift-authentication

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -128,6 +128,8 @@ var _clusterBootstrap00000_namespacesNeededForMonitoringYaml = []byte(`---
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    openshift.io/user-monitoring: "false"
   name: openshift-apiserver
 ---
 apiVersion: v1
@@ -150,6 +152,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    openshift.io/user-monitoring: "false"
   name: openshift-kube-controller-manager
 ---
 apiVersion: v1
@@ -168,6 +172,8 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    openshift.io/user-monitoring: "false"
   name: openshift-authentication
 `)
 


### PR DESCRIPTION
When user workload monitoring is enabled, we get alerts related to
ServiceMonitors using bearer tokens. Adding the
openshift.io/user-monitoring="false" label tells user workload
monitoring to skip this namespace. Since they aren't labeled as
cluster-monitoring, we've effectively told both cluster and user
workload monitoring to ignore the ServiceMonitors.
