### PR TITLE
ROKS 4: Set audit-log-maxbackup variable on OpenShift API server

### DIFF
--- a/assets/openshift-apiserver/config.yaml
+++ b/assets/openshift-apiserver/config.yaml
@@ -15,6 +15,7 @@ aggregatorConfig:
 apiServerArguments:
   minimal-shutdown-duration:
   - 3s
+  audit-log-maxbackup: "10"
 auditConfig:
   auditFilePath: "/var/run/kubernetes/audit.log"
   enabled: true

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -4717,6 +4717,7 @@ aggregatorConfig:
 apiServerArguments:
   minimal-shutdown-duration:
   - 3s
+  audit-log-maxbackup: "10"
 auditConfig:
   auditFilePath: "/var/run/kubernetes/audit.log"
   enabled: true


### PR DESCRIPTION
Related to this issue: https://github.ibm.com/alchemy-containers/armada-update/issues/3490