### PR TITLE
enforce privileged by default instead of restricted

### DIFF
--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -22,7 +22,7 @@ admission:
         kind: PodSecurityConfiguration
         apiVersion: pod-security.admission.config.k8s.io/v1beta1
         defaults:
-          enforce: "restricted"
+          enforce: "privileged"
           enforce-version: "latest"
           audit: "restricted"
           audit-version: "latest"

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2551,7 +2551,7 @@ admission:
         kind: PodSecurityConfiguration
         apiVersion: pod-security.admission.config.k8s.io/v1beta1
         defaults:
-          enforce: "restricted"
+          enforce: "privileged"
           enforce-version: "latest"
           audit: "restricted"
           audit-version: "latest"


### PR DESCRIPTION
Issue: https://github.ibm.com/alchemy-containers/armada-update/issues/3600

Change is to match OpenShift's cluster-kube-apiserver-operator changes https://github.com/openshift/cluster-kube-apiserver-operator/commit/8350321eb6d61629e1fb5bdf019200d6cda4c0be.