### PR TITLE
Update go version to 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12 as builder
 RUN mkdir -p /go/src/github.com/openshift/ibm-roks-toolkit
 WORKDIR /go/src/github.com/openshift/ibm-roks-toolkit
 COPY . .

--- a/Dockerfile.cpoperator
+++ b/Dockerfile.cpoperator
@@ -1,5 +1,5 @@
 # Image build must be run from repository root directory
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12 as builder
 RUN mkdir -p /go/src/github.com/openshift/ibm-roks-toolkit
 WORKDIR /go/src/github.com/openshift/ibm-roks-toolkit
 COPY . .

--- a/Dockerfile.metrics
+++ b/Dockerfile.metrics
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12 as builder
 RUN mkdir -p /go/src/github.com/openshift/ibm-roks-toolkit
 ENV PUSHGATEWAY_VERSION="1.3.0"
 WORKDIR /go/src/github.com/openshift/ibm-roks-toolkit

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SRC_DIRS = cmd pkg
-GOSEC_VERSION := v2.13.1
+GOSEC_VERSION := v2.14.0
 
 .PHONY: default
 default: build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/ibm-roks-toolkit
 
-go 1.18
+go 1.19
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/hack/releaser/Dockerfile
+++ b/hack/releaser/Dockerfile
@@ -1,7 +1,7 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12
 RUN yum -y install hub && yum clean all
 RUN cd /tmp && curl -OL \
-    https://github.com/goreleaser/goreleaser/releases/download/v0.174.2/goreleaser_Linux_x86_64.tar.gz && \
+    https://github.com/goreleaser/goreleaser/releases/download/v1.13.1/goreleaser_Linux_x86_64.tar.gz && \
     tar -xzf goreleaser_Linux_x86_64.tar.gz && \
     mv ./goreleaser /usr/bin/goreleaser && \
     rm ./goreleaser_Linux_x86_64.tar.gz

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -6240,11 +6240,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error

--- a/pkg/controllers/testconfigobserver/configobserver.go
+++ b/pkg/controllers/testconfigobserver/configobserver.go
@@ -52,14 +52,14 @@ type ConfigObserver struct {
 // Given the following configuration, you could run two separate controllers and point each to its own section.
 // The first controller would be responsible for "oauthAPIServer" and the second for "oauthServer" section.
 //
-// "observedConfig": {
-//   "oauthAPIServer": {
-//     "apiServerArguments": {"tls-min-version": "VersionTLS12"}
-//   },
-//   "oauthServer": {
-//     "corsAllowedOrigins": [ "//127\\.0\\.0\\.1(:|$)","//localhost(:|$)"]
-//   }
-// }
+//	"observedConfig": {
+//	  "oauthAPIServer": {
+//	    "apiServerArguments": {"tls-min-version": "VersionTLS12"}
+//	  },
+//	  "oauthServer": {
+//	    "corsAllowedOrigins": [ "//127\\.0\\.0\\.1(:|$)","//localhost(:|$)"]
+//	  }
+//	}
 //
 // oauthAPIController    := NewNestedConfigObserver(..., []string{"oauthAPIServer"}
 // oauthServerController := NewNestedConfigObserver(..., []string{"oauthServer"}


### PR DESCRIPTION
Updateing the Dockerfiles to use a 1.19 golang image when building the toolkit code. Also bumped the gosec version to v2.14.0