### PR TITLE
Fix hub install

### DIFF
--- a/hack/releaser/Dockerfile
+++ b/hack/releaser/Dockerfile
@@ -3,8 +3,9 @@ FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-open
 # doesn't work by default on a rhel8 image
 RUN curl -OL https://github.com/github/hub/releases/download/v2.14.2/hub-linux-amd64-2.14.2.tgz && \
     tar -xzf hub-linux-amd64-2.14.2.tgz && \
-    mv ./hub-linux-amd64-2.14.2 /usr/bin/hub && \
-    rm ./hub-linux-amd64-2.14.2.tgz
+    mv ./hub-linux-amd64-2.14.2/bin/hub /usr/bin/hub && \
+    rm ./hub-linux-amd64-2.14.2.tgz && \
+    rm -rf ./hub-linux-amd64-2.14.2
 RUN cd /tmp && curl -OL \
     https://github.com/goreleaser/goreleaser/releases/download/v1.13.1/goreleaser_Linux_x86_64.tar.gz && \
     tar -xzf goreleaser_Linux_x86_64.tar.gz && \


### PR DESCRIPTION
Using the correct file path when invoking hub. Tested here:
```
ibm-roks-toolkit$ docker run --rm -it --platform linux/amd64 test:v1.0 bash
[root@679ffd41324e origin]# which hub
/usr/bin/hub
[root@679ffd41324e origin]# hub --help
usage: git [--version] [--help] [-C <path>] [-c <name>=<value>]
           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
...
```