### PR TITLE
 Adding graceful shutdown delay interval

### DIFF
--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -72,7 +72,7 @@ spec:
 {{ if .MasterPriorityClass }}
       priorityClassName: {{ .MasterPriorityClass }}
 {{ end }}
-      terminationGracePeriodSeconds: 90
+      terminationGracePeriodSeconds: 120
       initContainers:
       - image: {{ imageFor "cluster-config-operator" }}
 {{- if .ClusterConfigOperatorSecurityContext }}
@@ -303,6 +303,8 @@ spec:
           value: /healthz
         - name: HEALTHZ_PORT
           value: ":8081"
+        - name: SHUTDOWN_DELAY_IN_SECONDS
+          value: "90"
         volumeMounts:
         - name: kms-socket
           mountPath: /tmp

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3178,6 +3178,8 @@ spec:
           value: /healthz
         - name: HEALTHZ_PORT
           value: ":8081"
+        - name: SHUTDOWN_DELAY_IN_SECONDS
+          value: "90"
         volumeMounts:
         - name: kms-socket
           mountPath: /tmp

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2947,7 +2947,7 @@ spec:
 {{ if .MasterPriorityClass }}
       priorityClassName: {{ .MasterPriorityClass }}
 {{ end }}
-      terminationGracePeriodSeconds: 90
+      terminationGracePeriodSeconds: 120
       initContainers:
       - image: {{ imageFor "cluster-config-operator" }}
 {{- if .ClusterConfigOperatorSecurityContext }}
@@ -4894,7 +4894,7 @@ spec:
 {{ if .MasterPriorityClass }}
       priorityClassName: {{ .MasterPriorityClass }}
 {{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 90
       containers:
       - name: openshift-apiserver
 {{- if .OpenshiftAPIServerSecurityContext }}

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -4894,7 +4894,7 @@ spec:
 {{ if .MasterPriorityClass }}
       priorityClassName: {{ .MasterPriorityClass }}
 {{ end }}
-      terminationGracePeriodSeconds: 90
+      terminationGracePeriodSeconds: 120
       containers:
       - name: openshift-apiserver
 {{- if .OpenshiftAPIServerSecurityContext }}


### PR DESCRIPTION
- Extending existing grace period from 90 to 120 seconds
- Adding env var for shutdown delay ( default to 90 seconds )

Signed-off-by: Dave Hay <david_hay@uk.ibm.com>