### PR TITLE
Add new OCP 4.13 storage admission plugin

### DIFF
--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -114,6 +114,7 @@ apiServerArguments:
   - security.openshift.io/SCCExecRestrictions
   - security.openshift.io/SecurityContextConstraint
   - security.openshift.io/ValidateSecurityContextConstraints
+  - storage.openshift.io/CSIInlineVolumeSecurity
   enable-aggregator-routing:
   - 'true'
   enable-logs-handler:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2654,6 +2654,7 @@ apiServerArguments:
   - security.openshift.io/SCCExecRestrictions
   - security.openshift.io/SecurityContextConstraint
   - security.openshift.io/ValidateSecurityContextConstraints
+  - storage.openshift.io/CSIInlineVolumeSecurity
   enable-aggregator-routing:
   - 'true'
   enable-logs-handler:


### PR DESCRIPTION
Details on new OpenShift admission plugin:
https://github.com/openshift/cluster-kube-apiserver-operator/blob/3e62b53e39db960ccc16d717d1a25d751d4e9c49/bindata/assets/config/defaultconfig.yaml#L100
```
storage.openshift.io/CSIInlineVolumeSecurity
```
- RH Jira: https://issues.redhat.com/browse/STOR-829
- PR: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1385
- Enhancement: https://github.com/openshift/enhancements/blob/master/enhancements/storage/csi-inline-vol-security.md

The admission plugin has been added and enabled by default in OCP 4.13.

Background:
The admission plugin adds extra checks for CSI drivers that enabled this `Ephemeral` volume lifecycle mode (like this: https://github.com/openshift/csi-driver-shared-resource-operator/blob/7f4d3da21d129153bad447562d81a92f610b33ff/assets/csidriver.yaml#L13)