### PR TITLE
Migrate to lease objects for leader election

### DIFF
--- a/assets/kube-controller-manager/kube-controller-manager-deployment.yaml
+++ b/assets/kube-controller-manager/kube-controller-manager-deployment.yaml
@@ -100,7 +100,7 @@ spec:
         - "--flex-volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec"
         - "--kube-api-burst=300"
         - "--kube-api-qps=150"
-        - "--leader-elect-resource-lock=configmapsleases"
+        - "--leader-elect-resource-lock=leases"
         - "--leader-elect=true"
         - "--leader-elect-lease-duration=137s"
         - "--leader-elect-renew-deadline=107s"

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3604,7 +3604,7 @@ spec:
         - "--flex-volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec"
         - "--kube-api-burst=300"
         - "--kube-api-qps=150"
-        - "--leader-elect-resource-lock=configmapsleases"
+        - "--leader-elect-resource-lock=leases"
         - "--leader-elect=true"
         - "--leader-elect-lease-duration=137s"
         - "--leader-elect-renew-deadline=107s"


### PR DESCRIPTION
Mirroring changes made in OpenShift: https://github.com/openshift/cluster-kube-controller-manager-operator/pull/715

Should help mitigate issues experienced with `configmapsleases` resource locking.