### PR TITLE
Enable strict-transport-security for kube-apiserver

### DIFF
--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -195,12 +195,12 @@ apiServerArguments:
   - etcd3
   storage-media-type:
   - application/vnd.kubernetes.protobuf
+  strict-transport-security-directives:
+  - max-age=31536000
   tls-cert-file:
   - /etc/kubernetes/secret/server.crt
   tls-private-key-file:
   - /etc/kubernetes/secret/server.key
-  strict-transport-security-directives:
-  - max-age=31536000
 authConfig:
   oauthMetadataFile: "/etc/kubernetes/oauth/oauthMetadata.json"
 consolePublicURL: 'https://console-openshift-console.{{ .IngressSubdomain }}'

--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -199,6 +199,8 @@ apiServerArguments:
   - /etc/kubernetes/secret/server.crt
   tls-private-key-file:
   - /etc/kubernetes/secret/server.key
+  strict-transport-security-directives:
+  - max-age=31536000
 authConfig:
   oauthMetadataFile: "/etc/kubernetes/oauth/oauthMetadata.json"
 consolePublicURL: 'https://console-openshift-console.{{ .IngressSubdomain }}'

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2867,12 +2867,12 @@ apiServerArguments:
   - etcd3
   storage-media-type:
   - application/vnd.kubernetes.protobuf
+  strict-transport-security-directives:
+  - max-age=31536000
   tls-cert-file:
   - /etc/kubernetes/secret/server.crt
   tls-private-key-file:
   - /etc/kubernetes/secret/server.key
-  strict-transport-security-directives:
-  - max-age=31536000
 authConfig:
   oauthMetadataFile: "/etc/kubernetes/oauth/oauthMetadata.json"
 consolePublicURL: 'https://console-openshift-console.{{ .IngressSubdomain }}'

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2871,6 +2871,8 @@ apiServerArguments:
   - /etc/kubernetes/secret/server.crt
   tls-private-key-file:
   - /etc/kubernetes/secret/server.key
+  strict-transport-security-directives:
+  - max-age=31536000
 authConfig:
   oauthMetadataFile: "/etc/kubernetes/oauth/oauthMetadata.json"
 consolePublicURL: 'https://console-openshift-console.{{ .IngressSubdomain }}'


### PR DESCRIPTION
Adds strict-transport-security-directives to the KubeApiServerConfig.