### PR TITLE
Featuregate information now required

### DIFF
--- a/assets/kube-apiserver/cluster-featuregate.yaml
+++ b/assets/kube-apiserver/cluster-featuregate.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cluster-featuregate
+data:
+  cluster-featuregate.yaml: |-
+{{ include "kube-apiserver/featuregate.yaml" 4 }}

--- a/assets/kube-apiserver/featuregate.yaml
+++ b/assets/kube-apiserver/featuregate.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: CustomNoUpgrade
+  customNoUpgrade:
+    enabled:
+    - RotateKubeletServerCertificate
+    disabled:
+    - RetroactiveDefaultStorageClass

--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -90,11 +90,14 @@ spec:
         - |-
           cd /tmp
           mkdir input output
-          /usr/bin/cluster-config-operator render --config-output-file config --asset-input-dir /tmp/input --asset-output-dir /tmp/output
+          cp /features/cluster-featuregate.yaml /tmp/input
+          /usr/bin/cluster-config-operator render --config-output-file config --asset-input-dir /tmp/input --asset-output-dir /tmp/output --rendered-manifest-files /tmp/input/cluster-featuregate.yaml
           cp /tmp/output/manifests/* /work
         volumeMounts:
         - mountPath: /work
           name: bootstrap-manifests
+        - mountPath: /features
+          name: cluster-featuregate
       containers:
       - image: {{ imageFor "cli" }}
 {{- if .ManifestBootstrapperSecurityContext }}
@@ -418,6 +421,10 @@ spec:
       - configMap:
           name: kube-apiserver-oauth-metadata
         name: oauth
+      - configMap:
+          name: cluster-featuregate
+          defaultMode: 0640
+        name: cluster-featuregate
       - secret:
           secretName: kube-apiserver-authentication-token-webhook-config
           defaultMode: 0640

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -33,8 +33,10 @@
 // assets/cluster-bootstrap/trust_distribution_rolebinding.yaml
 // assets/cluster-version-operator/cluster-version-operator-deployment.yaml
 // assets/control-plane-operator/cp-operator-deployment.yaml
+// assets/kube-apiserver/cluster-featuregate.yaml
 // assets/kube-apiserver/config.yaml
 // assets/kube-apiserver/default-audit-policy.yaml
+// assets/kube-apiserver/featuregate.yaml
 // assets/kube-apiserver/kube-apiserver-config-configmap.yaml
 // assets/kube-apiserver/kube-apiserver-default-audit-policy.yaml
 // assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -2670,6 +2672,30 @@ func controlPlaneOperatorCpOperatorDeploymentYaml() (*asset, error) {
 	return a, nil
 }
 
+var _kubeApiserverClusterFeaturegateYaml = []byte(`kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cluster-featuregate
+data:
+  cluster-featuregate.yaml: |-
+{{ include "kube-apiserver/featuregate.yaml" 4 }}
+`)
+
+func kubeApiserverClusterFeaturegateYamlBytes() ([]byte, error) {
+	return _kubeApiserverClusterFeaturegateYaml, nil
+}
+
+func kubeApiserverClusterFeaturegateYaml() (*asset, error) {
+	bytes, err := kubeApiserverClusterFeaturegateYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "kube-apiserver/cluster-featuregate.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _kubeApiserverConfigYaml = []byte(`---
 apiVersion: kubecontrolplane.config.openshift.io/v1
 kind: KubeAPIServerConfig
@@ -2971,6 +2997,34 @@ func kubeApiserverDefaultAuditPolicyYaml() (*asset, error) {
 	return a, nil
 }
 
+var _kubeApiserverFeaturegateYaml = []byte(`apiVersion: v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: CustomNoUpgrade
+  customNoUpgrade:
+    enabled:
+    - RotateKubeletServerCertificate
+    disabled:
+    - RetroactiveDefaultStorageClass
+`)
+
+func kubeApiserverFeaturegateYamlBytes() ([]byte, error) {
+	return _kubeApiserverFeaturegateYaml, nil
+}
+
+func kubeApiserverFeaturegateYaml() (*asset, error) {
+	bytes, err := kubeApiserverFeaturegateYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "kube-apiserver/featuregate.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _kubeApiserverKubeApiserverConfigConfigmapYaml = []byte(`kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -3111,11 +3165,14 @@ spec:
         - |-
           cd /tmp
           mkdir input output
-          /usr/bin/cluster-config-operator render --config-output-file config --asset-input-dir /tmp/input --asset-output-dir /tmp/output
+          cp /features/cluster-featuregate.yaml /tmp/input
+          /usr/bin/cluster-config-operator render --config-output-file config --asset-input-dir /tmp/input --asset-output-dir /tmp/output --rendered-manifest-files /tmp/input/cluster-featuregate.yaml
           cp /tmp/output/manifests/* /work
         volumeMounts:
         - mountPath: /work
           name: bootstrap-manifests
+        - mountPath: /features
+          name: cluster-featuregate
       containers:
       - image: {{ imageFor "cli" }}
 {{- if .ManifestBootstrapperSecurityContext }}
@@ -3439,6 +3496,10 @@ spec:
       - configMap:
           name: kube-apiserver-oauth-metadata
         name: oauth
+      - configMap:
+          name: cluster-featuregate
+          defaultMode: 0640
+        name: cluster-featuregate
       - secret:
           secretName: kube-apiserver-authentication-token-webhook-config
           defaultMode: 0640
@@ -6526,8 +6587,10 @@ var _bindata = map[string]func() (*asset, error){
 	"cluster-bootstrap/trust_distribution_rolebinding.yaml":                                   clusterBootstrapTrust_distribution_rolebindingYaml,
 	"cluster-version-operator/cluster-version-operator-deployment.yaml":                       clusterVersionOperatorClusterVersionOperatorDeploymentYaml,
 	"control-plane-operator/cp-operator-deployment.yaml":                                      controlPlaneOperatorCpOperatorDeploymentYaml,
+	"kube-apiserver/cluster-featuregate.yaml":                                                 kubeApiserverClusterFeaturegateYaml,
 	"kube-apiserver/config.yaml":                                                              kubeApiserverConfigYaml,
 	"kube-apiserver/default-audit-policy.yaml":                                                kubeApiserverDefaultAuditPolicyYaml,
+	"kube-apiserver/featuregate.yaml":                                                         kubeApiserverFeaturegateYaml,
 	"kube-apiserver/kube-apiserver-config-configmap.yaml":                                     kubeApiserverKubeApiserverConfigConfigmapYaml,
 	"kube-apiserver/kube-apiserver-default-audit-policy.yaml":                                 kubeApiserverKubeApiserverDefaultAuditPolicyYaml,
 	"kube-apiserver/kube-apiserver-deployment.yaml":                                           kubeApiserverKubeApiserverDeploymentYaml,
@@ -6669,8 +6732,10 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"cp-operator-deployment.yaml": {controlPlaneOperatorCpOperatorDeploymentYaml, map[string]*bintree{}},
 	}},
 	"kube-apiserver": {nil, map[string]*bintree{
+		"cluster-featuregate.yaml":                     {kubeApiserverClusterFeaturegateYaml, map[string]*bintree{}},
 		"config.yaml":                                  {kubeApiserverConfigYaml, map[string]*bintree{}},
 		"default-audit-policy.yaml":                    {kubeApiserverDefaultAuditPolicyYaml, map[string]*bintree{}},
+		"featuregate.yaml":                             {kubeApiserverFeaturegateYaml, map[string]*bintree{}},
 		"kube-apiserver-config-configmap.yaml":         {kubeApiserverKubeApiserverConfigConfigmapYaml, map[string]*bintree{}},
 		"kube-apiserver-default-audit-policy.yaml":     {kubeApiserverKubeApiserverDefaultAuditPolicyYaml, map[string]*bintree{}},
 		"kube-apiserver-deployment.yaml":               {kubeApiserverKubeApiserverDeploymentYaml, map[string]*bintree{}},


### PR DESCRIPTION
During ROKS 4.14 bringup, it was was discovered that `featuregate` information is now required.

```
$ kubectl logs -n master-cin9ks420488vf8s9beg kube-apiserver-54757949cd-jz4gd -c config-bootstrap
 
F0712 17:27:36.225575       8 render.go:53] problem with featuregate manifests: cannot return FeatureGate without rendered manifests
cp: cannot stat '/tmp/output/manifests/*': No such file or directory
```