### PR TITLE
Render cluster featuregate configmap

### DIFF
--- a/pkg/render/manifests.go
+++ b/pkg/render/manifests.go
@@ -87,6 +87,7 @@ func (c *clusterManifestContext) oauthOpenshiftServer() {
 
 func (c *clusterManifestContext) kubeAPIServer() {
 	c.addManifestFiles(
+		"kube-apiserver/cluster-featuregate.yaml",
 		"kube-apiserver/kube-apiserver-deployment.yaml",
 		"kube-apiserver/kube-apiserver-service.yaml",
 		"kube-apiserver/kube-apiserver-config-configmap.yaml",


### PR DESCRIPTION
Follow up PR (fix) for https://github.com/openshift/ibm-roks-toolkit/pull/776 to render the cluster featuregate configmap.