### PR TITLE
Enforce restricted pod security

### DIFF
--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -20,9 +20,9 @@ admission:
     PodSecurity:
       configuration:
         kind: PodSecurityConfiguration
-        apiVersion: pod-security.admission.config.k8s.io/v1beta1
+        apiVersion: pod-security.admission.config.k8s.io/v1
         defaults:
-          enforce: "privileged"
+          enforce: "restricted"
           enforce-version: "latest"
           audit: "restricted"
           audit-version: "latest"

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2718,9 +2718,9 @@ admission:
     PodSecurity:
       configuration:
         kind: PodSecurityConfiguration
-        apiVersion: pod-security.admission.config.k8s.io/v1beta1
+        apiVersion: pod-security.admission.config.k8s.io/v1
         defaults:
-          enforce: "privileged"
+          enforce: "restricted"
           enforce-version: "latest"
           audit: "restricted"
           audit-version: "latest"


### PR DESCRIPTION
Enforce `restricted` pod security (now the default in OCP `v4.14`).