### PR TITLE
Reconcile admission plugins

### DIFF
--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -92,6 +92,7 @@ apiServerArguments:
   - StorageObjectInUseProtection
   - TaintNodesByCondition
   - ValidatingAdmissionWebhook
+  - ValidatingAdmissionPolicy
   - authorization.openshift.io/RestrictSubjectBindings
   - authorization.openshift.io/ValidateRoleBindingRestriction
   - config.openshift.io/DenyDeleteClusterConfiguration

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2790,6 +2790,7 @@ apiServerArguments:
   - StorageObjectInUseProtection
   - TaintNodesByCondition
   - ValidatingAdmissionWebhook
+  - ValidatingAdmissionPolicy
   - authorization.openshift.io/RestrictSubjectBindings
   - authorization.openshift.io/ValidateRoleBindingRestriction
   - config.openshift.io/DenyDeleteClusterConfiguration


### PR DESCRIPTION
Reconcile enabled admission plugins in `ibm-roks-toolkit`  `kube-apiserver` config with `openshift` `cluster-kube-apiserver-operator` config.

Note: At the moment, `hypershift control plane operator` `kas` config does NOT match and is missing admission plugin added to `ibm-roks-toolkit` `kube-apiserver` config.

Additional information on the admission plugin being added: https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/#before-you-begin