### PR TITLE
Update to dynamic featuregate config

### DIFF
--- a/assets/kube-apiserver/featuregate.yaml
+++ b/assets/kube-apiserver/featuregate.yaml
@@ -2,10 +2,14 @@ apiVersion: config.openshift.io/v1
 kind: FeatureGate
 metadata:
   name: cluster
-spec:
+{{ if .ExtraFeatureGates }}spec:
   featureSet: CustomNoUpgrade
   customNoUpgrade:
-    enabled:
-    - RotateKubeletServerCertificate
-    disabled:
-    - RetroactiveDefaultStorageClass
+{{ if .ExtraFeatureGatesEnabled }}{{ printf "%s\n" "    enabled:" }}
+{{- range $featureGateEnabled := .ExtraFeatureGatesEnabled }}{{ printf "%s %s" "    -" $featureGateEnabled }}{{ end }}
+{{ end -}}
+{{ if .ExtraFeatureGatesDisabled }}{{ printf "%s\n" "    disabled:" }}
+{{- range $featureGateDisabled := .ExtraFeatureGatesDisabled }}{{ printf "%s %s" "    -" $featureGateDisabled }}{{ end }}
+{{ end -}}
+{{ else }}spec: {}
+{{ end -}}

--- a/cluster.yaml.example
+++ b/cluster.yaml.example
@@ -151,8 +151,9 @@ kmsAPIKey: abcdefghijklmnopqrstuvwxyz
 kpInfo: '{"example":"foobar"}'
 kpRegion: us-south
 restartDate: "2022-01-07T13:58:11Z"
-extraFeatureGates: [ExpandInUsePersistentVolumes=true, RotateKubeletServerCertificate=true, DownwardAPIHugePages=true,
-  ServiceLBNodePortControl=false]
+extraFeatureGates: [RotateKubeletServerCertificate=true,RetroactiveDefaultStorageClass=false]
+extraFeatureGatesEnabled: [RotateKubeletServerCertificate]
+extraFeatureGatesDisabled: [RetroactiveDefaultStorageClass]
 apiServerAuditEnabled: true
 controlPlaneOperatorImage: registry.ng.bluemix.net/armada-master/ocp-control-plane-operator:v4.9.0-20211201
 apiserverLivenessProbe:

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -57,6 +57,8 @@ type ClusterParams struct {
 	ROKSMetricsSecurityContextMaster          *SecurityContext       `json:"roksMetricsSecurityContextMaster"`
 	ROKSMetricsSecurityContextWorker          *SecurityContext       `json:"roksMetricsSecurityContextWorker"`
 	ExtraFeatureGates                         []string               `json:"extraFeatureGates"`
+	ExtraFeatureGatesEnabled                  []string               `json:"extraFeatureGatesEnabled"`
+	ExtraFeatureGatesDisabled                 []string               `json:"extraFeatureGatesDisabled"`
 	ControlPlaneOperatorSecurityContext       *SecurityContext       `json:"controlPlaneOperatorSecurityContext"`
 	MasterPriorityClass                       string                 `json:"masterPriorityClass"`
 	ApiserverLivenessPath                     string                 `json:"apiserverLivenessPath"`

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3002,13 +3002,17 @@ var _kubeApiserverFeaturegateYaml = []byte(`apiVersion: config.openshift.io/v1
 kind: FeatureGate
 metadata:
   name: cluster
-spec:
+{{ if .ExtraFeatureGates }}spec:
   featureSet: CustomNoUpgrade
   customNoUpgrade:
-    enabled:
-    - RotateKubeletServerCertificate
-    disabled:
-    - RetroactiveDefaultStorageClass
+{{ if .ExtraFeatureGatesEnabled }}{{ printf "%s\n" "    enabled:" }}
+{{- range $featureGateEnabled := .ExtraFeatureGatesEnabled }}{{ printf "%s %s" "    -" $featureGateEnabled }}{{ end }}
+{{ end -}}
+{{ if .ExtraFeatureGatesDisabled }}{{ printf "%s\n" "    disabled:" }}
+{{- range $featureGateDisabled := .ExtraFeatureGatesDisabled }}{{ printf "%s %s" "    -" $featureGateDisabled }}{{ end }}
+{{ end -}}
+{{ else }}spec: {}
+{{ end -}}
 `)
 
 func kubeApiserverFeaturegateYamlBytes() ([]byte, error) {


### PR DESCRIPTION
With addition of new featuregate vars, we are able to have a 'dynamic' featuregate config.

See test plan [comment](https://github.com/openshift/ibm-roks-toolkit/pull/806#issuecomment-1703081750) for testing performed.

For reference: this is the current working/tested config (which is 'statically' set and was only temporary while a 'dynamic' solution was worked out).

```
apiVersion: config.openshift.io/v1
kind: FeatureGate
metadata:
  name: cluster
spec:
  featureSet: CustomNoUpgrade
  customNoUpgrade:
    enabled:
    - RotateKubeletServerCertificate
    disabled:
    - RetroactiveDefaultStorageClass
```