### PR TITLE
create-release: background wait-for-images.sh

### DIFF
--- a/hack/create-release.sh
+++ b/hack/create-release.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 REPODIR="$(dirname "$0")/.."
 
-${REPODIR}/hack/wait-for-images.sh
+${REPODIR}/hack/wait-for-images.sh &
 ${REPODIR}/hack/create-git-release.sh
 ${REPODIR}/hack/tag-release-images.sh
+wait


### PR DESCRIPTION
It looks like wait-for-images.sh is supposed to run in the background while it waits for the other two scripts in create-release to... create the things it's waiting for :)

As previously written, it happily times out.