### PR TITLE
Set default pod security enforcement to privileged

### DIFF
--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -22,7 +22,7 @@ admission:
         kind: PodSecurityConfiguration
         apiVersion: pod-security.admission.config.k8s.io/v1
         defaults:
-          enforce: "restricted"
+          enforce: "privileged"
           enforce-version: "latest"
           audit: "restricted"
           audit-version: "latest"

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2747,7 +2747,7 @@ admission:
         kind: PodSecurityConfiguration
         apiVersion: pod-security.admission.config.k8s.io/v1
         defaults:
-          enforce: "restricted"
+          enforce: "privileged"
           enforce-version: "latest"
           audit: "restricted"
           audit-version: "latest"


### PR DESCRIPTION
Change due to recent update in OCP 4.14 (https://github.com/openshift/api/pull/1575)