### PR TITLE
Set goaway-chance on kube-apiserver to 0.001

### DIFF
--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -139,7 +139,7 @@ apiServerArguments:
   {{ end }}{{ range $featureGate := .ExtraFeatureGates }}- {{ $featureGate }}
   {{ end }}
   goaway-chance:
-  - '0'
+  - '0.001'
   http2-max-streams-per-connection:
   - '2000'
   profiling:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -2864,7 +2864,7 @@ apiServerArguments:
   {{ end }}{{ range $featureGate := .ExtraFeatureGates }}- {{ $featureGate }}
   {{ end }}
   goaway-chance:
-  - '0'
+  - '0.001'
   http2-max-streams-per-connection:
   - '2000'
   profiling:


### PR DESCRIPTION
Help to mitigate HTTP/2 attacks on the Kubernetes API Server