### PR TITLE
Add shutdown-duration-delay to openshift-apiserver

### DIFF
--- a/assets/openshift-apiserver/config.yaml
+++ b/assets/openshift-apiserver/config.yaml
@@ -13,8 +13,10 @@ aggregatorConfig:
   usernameHeaders:
   - X-Remote-User
 apiServerArguments:
-  minimal-shutdown-duration:
-  - 3s
+  shutdown-delay-duration:
+  - 15s
+  shutdown-send-retry-after:
+  - "true"
 auditConfig:
   auditFilePath: "/var/run/kubernetes/audit.log"
   enabled: true

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -5630,8 +5630,10 @@ aggregatorConfig:
   usernameHeaders:
   - X-Remote-User
 apiServerArguments:
-  minimal-shutdown-duration:
-  - 3s
+  shutdown-delay-duration:
+  - 15s
+  shutdown-send-retry-after:
+  - "true"
 auditConfig:
   auditFilePath: "/var/run/kubernetes/audit.log"
   enabled: true


### PR DESCRIPTION
This is meant to mirror changes made to core OpenShift via https://github.com/openshift/cluster-openshift-apiserver-operator/commit/cad9746b62abf3b3230592d45f7f60bcecc96dac