### PR TITLE
Featuregate config rendering fix

### DIFF
--- a/assets/kube-apiserver/featuregate.yaml
+++ b/assets/kube-apiserver/featuregate.yaml
@@ -6,10 +6,10 @@ metadata:
   featureSet: CustomNoUpgrade
   customNoUpgrade:
 {{ if .ExtraFeatureGatesEnabled }}{{ printf "%s\n" "    enabled:" }}
-{{- range $featureGateEnabled := .ExtraFeatureGatesEnabled }}{{ printf "%s %s" "    -" $featureGateEnabled }}{{ end }}
-{{ end -}}
+{{- range $featureGateEnabled := .ExtraFeatureGatesEnabled }}{{ printf "%s %s\n" "    -" $featureGateEnabled }}{{- end -}}
+{{- end -}}
 {{ if .ExtraFeatureGatesDisabled }}{{ printf "%s\n" "    disabled:" }}
-{{- range $featureGateDisabled := .ExtraFeatureGatesDisabled }}{{ printf "%s %s" "    -" $featureGateDisabled }}{{ end }}
-{{ end -}}
+{{- range $featureGateDisabled := .ExtraFeatureGatesDisabled }}{{ printf "%s %s\n" "    -" $featureGateDisabled }}{{- end -}}
+{{- end -}}
 {{ else }}spec: {}
-{{ end -}}
+{{- end -}}

--- a/cluster.yaml.example
+++ b/cluster.yaml.example
@@ -151,9 +151,9 @@ kmsAPIKey: abcdefghijklmnopqrstuvwxyz
 kpInfo: '{"example":"foobar"}'
 kpRegion: us-south
 restartDate: "2022-01-07T13:58:11Z"
-extraFeatureGates: [RotateKubeletServerCertificate=true,RetroactiveDefaultStorageClass=false]
+extraFeatureGates: [RotateKubeletServerCertificate=true]
 extraFeatureGatesEnabled: [RotateKubeletServerCertificate]
-extraFeatureGatesDisabled: [RetroactiveDefaultStorageClass]
+extraFeatureGatesDisabled: []
 apiServerAuditEnabled: true
 controlPlaneOperatorImage: registry.ng.bluemix.net/armada-master/ocp-control-plane-operator:v4.9.0-20211201
 apiserverLivenessProbe:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3694,13 +3694,13 @@ metadata:
   featureSet: CustomNoUpgrade
   customNoUpgrade:
 {{ if .ExtraFeatureGatesEnabled }}{{ printf "%s\n" "    enabled:" }}
-{{- range $featureGateEnabled := .ExtraFeatureGatesEnabled }}{{ printf "%s %s" "    -" $featureGateEnabled }}{{ end }}
-{{ end -}}
+{{- range $featureGateEnabled := .ExtraFeatureGatesEnabled }}{{ printf "%s %s\n" "    -" $featureGateEnabled }}{{- end -}}
+{{- end -}}
 {{ if .ExtraFeatureGatesDisabled }}{{ printf "%s\n" "    disabled:" }}
-{{- range $featureGateDisabled := .ExtraFeatureGatesDisabled }}{{ printf "%s %s" "    -" $featureGateDisabled }}{{ end }}
-{{ end -}}
+{{- range $featureGateDisabled := .ExtraFeatureGatesDisabled }}{{ printf "%s %s\n" "    -" $featureGateDisabled }}{{- end -}}
+{{- end -}}
 {{ else }}spec: {}
-{{ end -}}
+{{- end -}}
 `)
 
 func kubeApiserverFeaturegateYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Problem:

Featuregate rendering fails when there is more than one enabled or disabled featuregate. 

```
(initialize-manifests container log)
Warning: resource featuregates/cluster is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by oc apply. oc apply should only be used on resources created declaratively by either oc create --save-config or oc apply. The missing annotation will be patched automatically.
The FeatureGate "cluster" is invalid: spec.customNoUpgrade.enabled[0]: Invalid value: "RotateKubeletServerCertificate    - cloudDualStackNodeIPs": spec.customNoUpgrade.enabled[0] in body should match '^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$'
```

(roks toolkit - demonstrating error with more than one enabled featuregate)
```
kind: ConfigMap
apiVersion: v1
metadata:
  name: cluster-featuregate
data:
  cluster-featuregate.yaml: |-
    apiVersion: config.openshift.io/v1
    kind: FeatureGate
    metadata:
      name: cluster
    spec:
      featureSet: CustomNoUpgrade
      customNoUpgrade:
        enabled:
        - RotateKubeletServerCertificate    - CloudDualStackNodeIPs
        disabled:
        - RetroactiveDefaultStorageClass
```