### PR TITLE
Konnectivity update: use clusterIP service instead of localhost in kube-api egress config

### DIFF
--- a/assets/konnectivity/konnectivity-agent-control-plane-deployment.yaml
+++ b/assets/konnectivity/konnectivity-agent-control-plane-deployment.yaml
@@ -86,9 +86,9 @@ spec:
           "--health-server-port={{ .KonnectivityAgentHealthPort }}",
           "--agent-identifiers=ipv4={{ .OpenShiftAPIClusterIP }}&ipv4={{ .OauthAPIClusterIP }}",
           "--keepalive-time=30s",
-          "--probe-interval=30s",
-          "--sync-interval=1m",
-          "--sync-interval-cap=5m",
+          "--probe-interval=5s",
+          "--sync-interval=5s",
+          "--sync-interval-cap=30s",
           "--v=3",
           ]
 {{- if .KonnectivityAgentControlPlaneContainerResources }}

--- a/assets/konnectivity/konnectivity-agent-data-plane-daemonset.yaml
+++ b/assets/konnectivity/konnectivity-agent-data-plane-daemonset.yaml
@@ -41,9 +41,9 @@ spec:
           "--agent-key=/etc/konnectivity/agent/tls.key",
           "--agent-identifiers=default-route=true",
           "--keepalive-time=30s",
-          "--probe-interval=30s",
-          "--sync-interval=1m",
-          "--sync-interval-cap=5m",
+          "--probe-interval=5s",
+          "--sync-interval=5s",
+          "--sync-interval-cap=30s",
           "--v=3"
           ]
         livenessProbe:

--- a/assets/kube-apiserver/kube-apiserver-egress-config-configmap.yaml
+++ b/assets/kube-apiserver/kube-apiserver-egress-config-configmap.yaml
@@ -18,7 +18,7 @@ data:
           proxyProtocol: HTTPConnect
           transport:
             TCP:
-              URL: https://127.0.0.1:{{ .KonnectivityServerClusterPort }}
+              URL: https://konnectivity-server-local.master-{{ .ClusterID }}.svc:{{ .KonnectivityServerClusterPort }}
               TLSConfig:
                 CABundle: /etc/kubernetes/secret/ca.crt
                 ClientKey: /etc/kubernetes/secret/konnectivity-client.key

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3153,9 +3153,9 @@ spec:
           "--health-server-port={{ .KonnectivityAgentHealthPort }}",
           "--agent-identifiers=ipv4={{ .OpenShiftAPIClusterIP }}&ipv4={{ .OauthAPIClusterIP }}",
           "--keepalive-time=30s",
-          "--probe-interval=30s",
-          "--sync-interval=1m",
-          "--sync-interval-cap=5m",
+          "--probe-interval=5s",
+          "--sync-interval=5s",
+          "--sync-interval-cap=30s",
           "--v=3",
           ]
 {{- if .KonnectivityAgentControlPlaneContainerResources }}
@@ -3261,9 +3261,9 @@ spec:
           "--agent-key=/etc/konnectivity/agent/tls.key",
           "--agent-identifiers=default-route=true",
           "--keepalive-time=30s",
-          "--probe-interval=30s",
-          "--sync-interval=1m",
-          "--sync-interval-cap=5m",
+          "--probe-interval=5s",
+          "--sync-interval=5s",
+          "--sync-interval-cap=30s",
           "--v=3"
           ]
         livenessProbe:
@@ -4373,7 +4373,7 @@ data:
           proxyProtocol: HTTPConnect
           transport:
             TCP:
-              URL: https://127.0.0.1:{{ .KonnectivityServerClusterPort }}
+              URL: https://konnectivity-server-local.master-{{ .ClusterID }}.svc:{{ .KonnectivityServerClusterPort }}
               TLSConfig:
                 CABundle: /etc/kubernetes/secret/ca.crt
                 ClientKey: /etc/kubernetes/secret/konnectivity-client.key


### PR DESCRIPTION
- to avoid APIService flapping
- use more aggressive timers for connection management - agents will connect earlier if the server connection breaks

`sync-interval` - The initial interval by which the agent periodically checks if it has connections to all instances of the proxy server.
`probe-interval` - The interval by which the agent periodically checks if its connections to the proxy server are ready.
`sync-interval-cap` - The maximum interval for the SyncInterval to back off to when unable to connect to the proxy server.

Defaults are sync-interval:1s, probe-interval:1s and sync-interval-cap:10s.