### PR TITLE
Disable KMS automatic config reload

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "vendor/*|go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-11-24T13:19:09Z",
+  "generated_at": "2024-02-26T15:39:53Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -148,7 +148,7 @@
         "hashed_secret": "733c83df12b5f09020cfc0ad9411ba17e7d1a093",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4592,
+        "line_number": 4657,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5257,
+        "line_number": 5322,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/assets/kube-apiserver/kube-apiserver-deployment.yaml
+++ b/assets/kube-apiserver/kube-apiserver-deployment.yaml
@@ -158,6 +158,7 @@ spec:
         - "--openshift-config=/etc/kubernetes/apiserver-config/config.yaml"
 {{- if .KPInfo }}
         - "--encryption-provider-config=/etc/kubernetes/kms-config/config.yaml"
+        - "--encryption-provider-config-automatic-reload=false"
 {{- end }}
 {{- if .KonnectivityEnabled }}
         - "--egress-selector-config-file=/etc/kubernetes/apiserver-egress-config/egress-config.yaml"

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3926,6 +3926,7 @@ spec:
         - "--openshift-config=/etc/kubernetes/apiserver-config/config.yaml"
 {{- if .KPInfo }}
         - "--encryption-provider-config=/etc/kubernetes/kms-config/config.yaml"
+        - "--encryption-provider-config-automatic-reload=false"
 {{- end }}
 {{- if .KonnectivityEnabled }}
         - "--egress-selector-config-file=/etc/kubernetes/apiserver-egress-config/egress-config.yaml"


### PR DESCRIPTION
Don't reload on config changes to prevent issues with upgrade scenarios in the future (removing kms v1 provider). That is, for the rolling upgrade, we don't want the original containers to crash if the kms-config changes are incompatible.