### PR TITLE
WIP: support additional konnectivity agent identifiers (e.g calico API server)

### DIFF
--- a/assets/konnectivity/konnectivity-agent-control-plane-deployment.yaml
+++ b/assets/konnectivity/konnectivity-agent-control-plane-deployment.yaml
@@ -84,7 +84,7 @@ spec:
           "--proxy-server-host=konnectivity-server.{{ .Namespace }}.svc",
           "--proxy-server-port={{ .KonnectivityAgentClusterPort }}",
           "--health-server-port={{ .KonnectivityAgentHealthPort }}",
-          "--agent-identifiers=ipv4={{ .OpenShiftAPIClusterIP }}&ipv4={{ .OauthAPIClusterIP }}",
+          "--agent-identifiers=ipv4={{ .OpenShiftAPIClusterIP }}&ipv4={{ .OauthAPIClusterIP }}{{ range $agentIdentifier := .KonnectivityAdditionalAgentIdentifierIPList }}&ipv4={{ $agentIdentifier }}{{ end }}",
           "--keepalive-time=30s",
           "--probe-interval=5s",
           "--sync-interval=5s",

--- a/cluster.using.konnectivity.yaml.example
+++ b/cluster.using.konnectivity.yaml.example
@@ -239,6 +239,8 @@ konnectivityAgentHealthPort: 8093
 konnectivityServerAdminPort: 8095
 konnectivityServerNodePort: 32321
 konnectivityServerCipherSuites: 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384'
+KonnectivityAdditionalAgentIdentifierIPList:
+    - 172.16.16.16
 openshiftAPIServerNoProxyHosts: "kube-apiserver,etcd,quay.io,registry.redhat.io"
 konnectivityServerContainerResources:
     - resourceRequest:

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -101,6 +101,7 @@ type ClusterParams struct {
 	KonnectivityServerHealthPort                    uint                   `json:"konnectivityServerHealthPort"`
 	KonnectivityServerAdminPort                     uint                   `json:"konnectivityServerAdminPort"`
 	KonnectivityServerCipherSuites                  string                 `json:"konnectivityServerCipherSuites"`
+	KonnectivityAdditionalAgentIdentifierIPList     []string               `json:"KonnectivityAdditionalAgentIdentifierIPList"`
 	Socks5ProxyContainerResources                   []ResourceRequirements `json:"socks5ProxyContainerResources"`
 	OpenshiftAPIServerNoProxyHosts                  string                 `json:"openshiftAPIServerNoProxyHosts"`
 }

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3151,7 +3151,7 @@ spec:
           "--proxy-server-host=konnectivity-server.{{ .Namespace }}.svc",
           "--proxy-server-port={{ .KonnectivityAgentClusterPort }}",
           "--health-server-port={{ .KonnectivityAgentHealthPort }}",
-          "--agent-identifiers=ipv4={{ .OpenShiftAPIClusterIP }}&ipv4={{ .OauthAPIClusterIP }}",
+          "--agent-identifiers=ipv4={{ .OpenShiftAPIClusterIP }}&ipv4={{ .OauthAPIClusterIP }}{{ range $agentIdentifier := .KonnectivityAdditionalAgentIdentifierIPList }}&ipv4={{ $agentIdentifier }}{{ end }}",
           "--keepalive-time=30s",
           "--probe-interval=5s",
           "--sync-interval=5s",


### PR DESCRIPTION
If control plane needs to host other additional api services then the konnectivity-agents on the contol plane needs to advertise those in their agent identifiers.