### PR TITLE
use dnsPolicy: Default for konnectivity-agent in data plane

### DIFF
--- a/assets/konnectivity/konnectivity-agent-data-plane-daemonset.yaml
+++ b/assets/konnectivity/konnectivity-agent-data-plane-daemonset.yaml
@@ -66,6 +66,7 @@ spec:
           name: konnectivity-ca
         - mountPath: /etc/konnectivity/agent
           name: agent-certs
+      dnsPolicy: Default
       tolerations:
       - operator: "Exists"
       volumes:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3328,6 +3328,7 @@ spec:
           name: konnectivity-ca
         - mountPath: /etc/konnectivity/agent
           name: agent-certs
+      dnsPolicy: Default
       tolerations:
       - operator: "Exists"
       volumes:


### PR DESCRIPTION
- Fix coreDNS interworking
- With the change, konnectivity-agent in data plane will use the name resolution configuration from the node
- This makes sure that the konnectivity-agent's `proxy-server-url` can be resolved even if coreDNS is down or mis-configured (e.g. VPE gateway can be resolved by VPC pDNS) 
- konnectivity-agent control plane shall not change as it still needs to use coreDNS as in that case a ClusterIP Service is configured as `proxy-server-url`