### PR TITLE
Remove '-operator' from machine config crd copy command

### DIFF
--- a/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
+++ b/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
@@ -62,7 +62,7 @@ spec:
           rm /tmp/output/manifests/0000_00_cluster-version-operator*deployment.yaml
           cp /tmp/output/manifests/* /work
           # Add machineconfig CRDs to prevent upgrade getting stuck
-          cp /release-manifests/*machine-config-operator*machineconfig*.crd.yaml /work
+          cp /release-manifests/*machine-config*machineconfig*.crd.yaml /work
       volumeMounts:
         - mountPath: /work
           name: work

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -7807,7 +7807,7 @@ spec:
           rm /tmp/output/manifests/0000_00_cluster-version-operator*deployment.yaml
           cp /tmp/output/manifests/* /work
           # Add machineconfig CRDs to prevent upgrade getting stuck
-          cp /release-manifests/*machine-config-operator*machineconfig*.crd.yaml /work
+          cp /release-manifests/*machine-config*machineconfig*.crd.yaml /work
       volumeMounts:
         - mountPath: /work
           name: work


### PR DESCRIPTION
We need to readjust the regex to reflect changes in how the machine config operator CRDs are named.