### PR TITLE
Exclude NoUpgrade CRDs

### DIFF
--- a/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
+++ b/assets/user-manifests-bootstrapper/user-manifests-bootstrapper-pod.yaml
@@ -61,6 +61,8 @@ spec:
           # Exclude the CVO deployment manifest
           rm /tmp/output/manifests/0000_00_cluster-version-operator*deployment.yaml
           cp /tmp/output/manifests/* /work
+          # Exclude NoUpgrade CRDs which are not GA
+          rm /release-manifests/*NoUpgrade.crd.yaml
           # Add machineconfig CRDs to prevent upgrade getting stuck
           cp /release-manifests/*machine-config*machineconfig*.crd.yaml /work
       volumeMounts:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -7806,6 +7806,8 @@ spec:
           # Exclude the CVO deployment manifest
           rm /tmp/output/manifests/0000_00_cluster-version-operator*deployment.yaml
           cp /tmp/output/manifests/* /work
+          # Exclude NoUpgrade CRDs which are not GA
+          rm /release-manifests/*NoUpgrade.crd.yaml
           # Add machineconfig CRDs to prevent upgrade getting stuck
           cp /release-manifests/*machine-config*machineconfig*.crd.yaml /work
       volumeMounts:


### PR DESCRIPTION
We need to include only GA CRDs in 4.16.