### PR TITLE
ROKS v4.16: Set default pod security enforcement to restricted to align with open…

### DIFF
--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -22,7 +22,7 @@ admission:
         kind: PodSecurityConfiguration
         apiVersion: pod-security.admission.config.k8s.io/v1
         defaults:
-          enforce: "privileged"
+          enforce: "restricted"
           enforce-version: "latest"
           audit: "restricted"
           audit-version: "latest"

--- a/assets/openshift-controller-manager/config.yaml
+++ b/assets/openshift-controller-manager/config.yaml
@@ -11,7 +11,7 @@ deployer:
 dockerPullSecret:
   internalRegistryHostname: image-registry.openshift-image-registry.svc:5000
 featureGates:
-- OpenShiftPodSecurityAdmission=false
+- OpenShiftPodSecurityAdmission=true
 ingress:
   ingressIPNetworkCIDR: ''
 kubeClientConfig:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -6814,7 +6814,7 @@ deployer:
 dockerPullSecret:
   internalRegistryHostname: image-registry.openshift-image-registry.svc:5000
 featureGates:
-- OpenShiftPodSecurityAdmission=false
+- OpenShiftPodSecurityAdmission=true
 ingress:
   ingressIPNetworkCIDR: ''
 kubeClientConfig:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3738,7 +3738,7 @@ admission:
         kind: PodSecurityConfiguration
         apiVersion: pod-security.admission.config.k8s.io/v1
         defaults:
-          enforce: "privileged"
+          enforce: "restricted"
           enforce-version: "latest"
           audit: "restricted"
           audit-version: "latest"


### PR DESCRIPTION
…shift defaults

We need to align pod security enforcement with OpenShift defaults in 4.16: https://github.com/openshift/ibm-roks-toolkit/blob/release-4.16/assets/kube-apiserver/config.yaml#L20.