### PR TITLE
revert PR #1034, set default pod security enforcement back to privileged

### DIFF
--- a/assets/kube-apiserver/config.yaml
+++ b/assets/kube-apiserver/config.yaml
@@ -22,7 +22,7 @@ admission:
         kind: PodSecurityConfiguration
         apiVersion: pod-security.admission.config.k8s.io/v1
         defaults:
-          enforce: "restricted"
+          enforce: "privileged"
           enforce-version: "latest"
           audit: "restricted"
           audit-version: "latest"

--- a/assets/openshift-controller-manager/config.yaml
+++ b/assets/openshift-controller-manager/config.yaml
@@ -11,7 +11,7 @@ deployer:
 dockerPullSecret:
   internalRegistryHostname: image-registry.openshift-image-registry.svc:5000
 featureGates:
-- OpenShiftPodSecurityAdmission=true
+- OpenShiftPodSecurityAdmission=false
 ingress:
   ingressIPNetworkCIDR: ''
 kubeClientConfig:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -3738,7 +3738,7 @@ admission:
         kind: PodSecurityConfiguration
         apiVersion: pod-security.admission.config.k8s.io/v1
         defaults:
-          enforce: "restricted"
+          enforce: "privileged"
           enforce-version: "latest"
           audit: "restricted"
           audit-version: "latest"
@@ -6814,7 +6814,7 @@ deployer:
 dockerPullSecret:
   internalRegistryHostname: image-registry.openshift-image-registry.svc:5000
 featureGates:
-- OpenShiftPodSecurityAdmission=true
+- OpenShiftPodSecurityAdmission=false
 ingress:
   ingressIPNetworkCIDR: ''
 kubeClientConfig:


### PR DESCRIPTION
Reverts https://github.com/openshift/ibm-roks-toolkit/pull/1034 now that OpenShift has changed their mind regarding pod security admission enforcement in OpenShift 4.16 (moving back to privileged by default https://github.com/openshift/api/pull/1912/).  Requires cherry-pick back to `release-4.16`.