### PR TITLE
Bump timeout in wait-for-images

### DIFF
--- a/hack/wait-for-images.sh
+++ b/hack/wait-for-images.sh
@@ -25,8 +25,8 @@ fi
 
 CURRENT_COMMIT="$(git rev-parse "${RELEASE_BRANCH}")"
 
-# Wait up to 45 minutes, otherwise exit
-timeout=45
+# Wait up to 2 hours, otherwise exit
+timeout=120
 
 while [ $timeout -gt 0 ]; do
   # Grab the digest from the first manifest image in the manifest list, which is only amd64


### PR DESCRIPTION
There is a slowdown in the CI, we need to wait longer for jobs to finish